### PR TITLE
Replace item-ref tuple with item itself

### DIFF
--- a/src/clj_money/api/reconciliations.clj
+++ b/src/clj_money/api/reconciliations.clj
@@ -13,6 +13,7 @@
             [clj-money.dates :as dates]
             [clj-money.util :as util]
             [clj-money.models :as models]
+            [clj-money.models.transaction-items :as itms]
             [clj-money.authorization.reconciliations]))
 
 (defn- symbolic-comparatives
@@ -64,12 +65,13 @@
                [:reconciliation/end-of-period
                 :reconciliation/balance
                 :reconciliation/status
-                :reconciliation/item-refs]))
+                :reconciliation/items]))
 
 (defn- create
   [{:keys [authenticated params] :as req}]
   (-> req
       extract-recon
+      (update-in-if [:reconciliation/items] itms/resolve-refs)
       (assoc :reconciliation/account {:id (:account-id params)})
       (authorize ::auth/create authenticated)
       models/put

--- a/src/clj_money/cached_accounts.cljs
+++ b/src/clj_money/cached_accounts.cljs
@@ -1,5 +1,6 @@
 (ns clj-money.cached-accounts
   (:require [cljs.pprint :refer [pprint]]
+            [clj-money.util :as util]
             [clj-money.state :refer [accounts]]
             [clj-money.accounts :refer [nest unnest]]
             [clj-money.api.accounts :as accts]))
@@ -13,7 +14,8 @@
                  (map identity))))
 
 (defn watch-entity
-  [_ _ _ current]
-  (reset! accounts nil)
+  [_ _ previous current]
+  (when-not (util/id= previous current)
+    (reset! accounts nil))
   (when current
     (fetch-accounts)))

--- a/src/clj_money/db/sql.clj
+++ b/src/clj_money/db/sql.clj
@@ -69,7 +69,7 @@
              :children-key :budget/items}]
    :reconciliation [{:parent? :reconciliation/end-of-period
                      :child? :transaction-item/reconciliation
-                     :children-key :reconciliation/item-refs}]
+                     :children-key :reconciliation/items}]
    :scheduled-transaction [{:parent? :scheduled-transaction/description
                             :child? :scheduled-transaction-item/action
                             :children-key :scheduled-transaction/items}]

--- a/src/clj_money/db/sql/reconciliations.clj
+++ b/src/clj_money/db/sql/reconciliations.clj
@@ -5,23 +5,15 @@
             [clj-money.db :as db]
             [clj-money.db.sql :as sql]))
 
-(defn- coerce
-  [m]
-  (update-in-if m [:reconciliation/status] name))
-
 (defmethod sql/before-save :reconciliation
   [recon]
-  (coerce recon))
+  (update-in-if recon [:reconciliation/status] name))
 
 (defmethod sql/after-read :reconciliation
   [recon]
   (-> recon
       (update-in [:reconciliation/status] keyword)
-      (update-in [:reconciliation/end-of-period] t/local-date)
-      (update-in [:reconciliation/items]
-                 (fn [items]
-                   (mapv #(select-keys % [:id :transaction/transaction-date])
-                         items)))))
+      (update-in [:reconciliation/end-of-period] t/local-date)))
 
 (defmethod sql/post-select :reconciliation
   [{:keys [storage]} reconciliations]

--- a/src/clj_money/db/sql/reconciliations.clj
+++ b/src/clj_money/db/sql/reconciliations.clj
@@ -27,10 +27,9 @@
   [{:keys [storage]} reconciliations]
   (map #(assoc %
                :reconciliation/items
-               (mapv (juxt :id :transaction/transaction-date)
-                     (db/select storage
-                                {:transaction-item/reconciliation %}
-                                {:select-also [:transaction/transaction-date]})))
+               (db/select storage
+                          {:transaction-item/reconciliation %}
+                          {:select-also [:transaction/transaction-date]}))
        reconciliations))
 
 (defmethod sql/deconstruct :reconciliation

--- a/src/clj_money/models/reconciliations.clj
+++ b/src/clj_money/models/reconciliations.clj
@@ -203,7 +203,7 @@
   (let [prep (prepare-item)
         existing-items (->> (fetch-items recon)
                             fullify-items
-                            (map prep))
+                            (mapv prep))
         ignore? (->> existing-items
                      (map :id)
                      set)

--- a/src/clj_money/models/transaction_items.clj
+++ b/src/clj_money/models/transaction_items.clj
@@ -34,7 +34,7 @@
                             :compare t/before?)
         criterion (if (apply = range)
                     (first range)
-                    [:between range])]
+                    (apply vector :between range))]
     (util/model-type
       {:id [:in (map :id items)]
        :transaction/transaction-date criterion}

--- a/src/clj_money/util.cljc
+++ b/src/clj_money/util.cljc
@@ -465,3 +465,9 @@
     (if m
       (keyword (nth m 1) (nth m 2))
       k)))
+
+(defn ->range
+  "Accepts a sequence of values and returns a tuple with the
+  first in the first position and the last in the second."
+  [vs & {:keys [compare] :or {compare <}}]
+  ((juxt first last) (sort compare vs)))

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -137,7 +137,10 @@
    [:td.text-center
     [:div.btn-group
      [:button.btn.btn-secondary.btn-sm
-      {:on-click #(swap! page-state assoc :view-account account)
+      {:on-click #(swap! page-state assoc :view-account (update-in account
+                                                                   [:account/commodity]
+                                                                   (comp (:commodities @page-state)
+                                                                         :id)))
        :title "Click here to view transactions for this account."}
       (icon :collection :size :small)]
      [:button.btn.btn-secondary.btn-sm
@@ -669,7 +672,7 @@
   ([page-state checked?]
   (swap! page-state
          update-in
-         [:reconciliation :reconciliation/item-refs]
+         [:reconciliation :clj-money.views.reconciliations/item-selection]
          merge
          (->> (:items @page-state)
               (map (comp #(vector % checked?)

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -213,17 +213,17 @@
                                (:id item)))
       :on-drag-over #(.preventDefault %)
       :on-drop #(handle-item-row-drop item % page-state)
-      :style (get-in @styles [(:id item)])}
+      :style (get-in styles [(:id item)])}
      [:td.text-end
       [:span.d-md-none (format-date transaction-date "M/d")]
       [:span.d-none.d-md-inline (format-date transaction-date)]]
-     [:td {:style (get-in @styles [(:id item)])} description]
+     [:td {:style (get-in styles [(:id item)])} description]
      [:td.text-end (format-quantity (polarize-quantity quantity
                                                        action
                                                        account)
                                     account)]
      [:td.text-center.d-none.d-md-table-cell
-      (if reconciliation
+      (if @reconciliation
         [forms/checkbox-input
          reconciliation
          [:clj-money.views.reconciliations/item-selection (:id item)]
@@ -237,7 +237,7 @@
      (when-not reconciliation
        [:td.text-end.d-none.d-md-table-cell (format-quantity balance
                                                              account)])
-     (when-not reconciliation
+     (when-not @reconciliation
        [:td
         [:div.btn-group
          [:button.btn.btn-secondary.btn-sm
@@ -277,7 +277,7 @@
         styles (r/cursor page-state [:item-row-styles])
         include-children? (r/cursor page-state [:include-children?])
         account (r/cursor page-state [:view-account])
-        reconciliation (r/cursor page-state [:reconciliation])
+        recon (r/cursor page-state [:reconciliation])
         filter-fn (make-reaction (fn []
                                    (if @include-children?
                                      identity
@@ -291,9 +291,9 @@
          [:th "Description"]
          [:th.text-end "Amount"]
          [:th.text-center.d-none.d-md-table-cell "Rec."]
-         (when-not @reconciliation
+         (when-not @recon
            [:th.text-end.d-none.d-md-table-cell "Balance"])
-         (when-not @reconciliation
+         (when-not @recon
            [:th (space)])]]
        [:tbody
         (cond
@@ -301,7 +301,7 @@
           (->> @items
                (filter @filter-fn)
                (map (item-row {:account @account
-                               :reconciliation @reconciliation
+                               :reconciliation recon
                                :styles styles}
                               page-state))
                doall)

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -53,9 +53,9 @@
                          :balance 400M
                          :status :completed
                          :end-of-period (t/local-date 2015 1 4)
-                         :item-refs [[(t/local-date 2015 1 1) 1000M]
-                                     [(t/local-date 2015 1 2) 500M]
-                                     [(t/local-date 2015 1 3) 100M]]}))
+                         :items [[(t/local-date 2015 1 1) 1000M]
+                                 [(t/local-date 2015 1 2) 500M]
+                                 [(t/local-date 2015 1 3) 100M]]}))
 
 (defn- get-reconciliations
   [email]
@@ -92,12 +92,13 @@
   (with-context recon-context
     (let [user (find-user email)
           account (find-account "Checking")
-          item-refs (if complete?
-                      (let [item (find-transaction-item [(t/local-date 2015 1 10)
-                                                         101M
-                                                         account])]
-                        [((juxt :id :transaction/transaction-date) item)])
-                      [])
+          items (if complete?
+                  (map #(select-keys % [:id :transaction/transaction-date])
+                       (models/select {:transaction-item/account account
+                                       :transaction-item/quantity 101M
+                                       :transaction/transaction-date (t/local-date 2015 1 10)}
+                                      {:select-also [:transaction/transaction-date]}))
+                  [])
           status (if complete?
                    :completed
                    :new)
@@ -108,7 +109,7 @@
                        (edn-body #:reconciliation{:end-of-period (t/local-date 2015 2 4)
                                                   :balance 299.0M
                                                   :status status
-                                                  :item-refs item-refs})
+                                                  :items items})
                        (add-auth user)
                        app
                        parse-edn-body)
@@ -151,7 +152,7 @@
                          :account "Checking"
                          :balance 299M
                          :status :new
-                         :item-refs [[(t/local-date 2015 1 10) 101M]]}))
+                         :items [[(t/local-date 2015 1 10) 101M]]}))
 
 (defn- update-reconciliation
   [email]
@@ -161,7 +162,7 @@
                                                  :reconciliations
                                                  (:id recon)))
                        (edn-body (-> recon
-                                     (dissoc :id :reconciliation/item-refs)
+                                     (dissoc :id :reconciliation/items)
                                      (assoc :reconciliation/status :completed)))
                        (add-auth (find-user email))
                        app

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -16,7 +16,6 @@
                                             basic-context
                                             find-user
                                             find-account
-                                            find-transaction-item
                                             find-reconciliation]]
             [clj-money.web.server :refer [app]]
             [clj-money.models :as models]))

--- a/test/clj_money/api/transaction_items_test.clj
+++ b/test/clj_money/api/transaction_items_test.clj
@@ -102,13 +102,13 @@
                       :credit-account "Checking"}
         #:reconciliation{:end-of-period (t/local-date 2017 1 31)
                          :account "Checking"
-                         :item-refs [[(t/local-date 2017 1 1) 1000M]
+                         :items [[(t/local-date 2017 1 1) 1000M]
                                      [(t/local-date 2017 1 8) 100M]]
                          :balance 900M
                          :status :completed}
         #:reconciliation{:end-of-period (t/local-date 2017 2 28)
                          :account "Checking"
-                         :item-refs [[(t/local-date 2017 1 14) 100M]]
+                         :items [[(t/local-date 2017 1 14) 100M]]
                          :balance 1000M
                          :status :new}))
 

--- a/test/clj_money/models/reconciliations_test.clj
+++ b/test/clj_money/models/reconciliations_test.clj
@@ -230,10 +230,12 @@
       #:reconciliation{:account (find-account "Checking")
                        :end-of-period (t/local-date 2017 1 31)
                        :balance 1500M
-                       :items [(find-transaction-item
-                                 [(t/local-date 2017 1 1)
-                                  1000M
-                                  "Checking"])]}
+                       :items (models/select
+                                (util/model-type
+                                  {:transaction/transaction-date (t/local-date 2017 1 1)
+                                   :transaction-item/quantity 1000M
+                                   :account/name "Checking"}
+                                  :transaction-item)) }
       {:reconciliation/items ["No item can belong to another reconciliation"]})))
 
 (deftest a-working-reconciliation-can-be-updated

--- a/test/clj_money/models/reconciliations_test.clj
+++ b/test/clj_money/models/reconciliations_test.clj
@@ -191,12 +191,12 @@
           car (find-account "Car")
           reserve (find-account "Reserve")
           items (->> *context*
-                         (filter (util/model-type? :transaction))
-                         (mapcat :transaction/items)
-                         (filter #(or (model= reserve
-                                              (:transaction-item/account %))
-                                      (model= car
-                                              (:transaction-item/account %)))))
+                     (filter (util/model-type? :transaction))
+                     (mapcat :transaction/items)
+                     (filter #(or (model= reserve
+                                          (:transaction-item/account %))
+                                  (model= car
+                                          (:transaction-item/account %)))))
           created (assert-created
                     #:reconciliation{:account savings
                                      :end-of-period (t/local-date 2015 1 31)

--- a/test/clj_money/models/reconciliations_test.clj
+++ b/test/clj_money/models/reconciliations_test.clj
@@ -190,6 +190,11 @@
     (let [savings (find-account "Savings")
           car (find-account "Car")
           reserve (find-account "Reserve")
+          simplify #(select-keys %
+                                 [:id
+                                  :transaction/transaction-date
+                                  :transaction-item/quantity
+                                  :transaction-item/action])
           items (->> *context*
                      (filter (util/model-type? :transaction))
                      (mapcat :transaction/items)
@@ -203,8 +208,12 @@
                                      :status :completed
                                      :balance 300M
                                      :items items})]
-      (is (= (set items)
-             (set (:reconciliation/items created)))))))
+      (is (= (->> items
+                  (map simplify)
+                  set)
+             (->> (:reconciliation/items created)
+                  (map simplify)
+                  set))))))
 
 (def ^:private working-rec-context
   (conj reconciliation-context

--- a/test/clj_money/models/reconciliations_test.clj
+++ b/test/clj_money/models/reconciliations_test.clj
@@ -27,9 +27,6 @@
 
 (use-fixtures :each reset-db)
 
-(def ^:private ->item-ref
-  (juxt :id :transaction/transaction-date))
-
 (def ^:private reconciliation-context
   (conj basic-context
         #:transaction{:transaction-date (t/local-date 2017 1 1)
@@ -63,8 +60,8 @@
                          :end-of-period (t/local-date 2017 1 1)
                          :balance 1000M
                          :status :completed
-                         :item-refs [[(t/local-date 2017 1 1)
-                                      1000M]]}))
+                         :items [[(t/local-date 2017 1 1)
+                                  1000M]]}))
 
 (def ^:private working-reconciliation-context
   (conj existing-reconciliation-context
@@ -72,14 +69,14 @@
                          :end-of-period (t/local-date 2017 1 3)
                          :balance 455M
                          :status :new
-                         :item-refs [[(t/local-date 2017 1 2)
-                                      500M]]}))
+                         :items [[(t/local-date 2017 1 2)
+                                  500M]]}))
 
 (defn- assert-created
   [attr]
   (helpers/assert-created attr
                           :refs [:reconciliation/account]
-                          :ignore-attributes [:reconciliation/item-refs]
+                          :ignore-attributes [:reconciliation/items]
                           :compare-result? false))
 
 (defn- attributes []
@@ -100,13 +97,14 @@
   (with-context reconciliation-context
     (let [checking (find-account "Checking")
           checking-items (models/select {:transaction-item/account checking
-                                         :transaction-item/quantity [:!= 45]})]
+                                         :transaction-item/quantity [:!= 45]}
+                                        {:select-also [:transaction/transaction-date]})]
       (assert-created (assoc (attributes)
-                             :reconciliation/item-refs (map ->item-ref checking-items)
+                             :reconciliation/items checking-items
                              :reconciliation/status :completed))
       (is (->> checking-items
-               (mapcat :transaction/items)
-               (every? :transaction/recondiliation))
+               (map models/find)
+               (every? :transaction-item/reconciliation))
           "specified transaction items are marked as reconciled")
       (is (not-any? :transaction/reconciliation
                     (remove #(util/model= checking (:transaction-item/account %))
@@ -147,17 +145,16 @@
              :reconciliation/status :bouncy)
       {:reconciliation/status ["Status must be new or completed"]})))
 
-(deftest item-refs-cannot-reference-items-that-belong-to-the-account-being-reconciled
+(deftest items-cannot-reference-items-that-belong-to-the-account-being-reconciled
   (with-context reconciliation-context
     (assert-invalid #:reconciliation{:account (find-account "Groceries")
                                      :end-of-period (t/local-date 2017 1 31)
                                      :balance 500M
-                                     :item-refs [(->item-ref
-                                                  (find-transaction-item
-                                                    [(t/local-date 2017 1 2)
-                                                     500M
-                                                     (find-account "Rent")]))]}
-                    {:reconciliation/item-refs ["All items must belong to the account being reconciled"]})))
+                                     :items [(find-transaction-item
+                                               [(t/local-date 2017 1 2)
+                                                500M
+                                                (find-account "Rent")])]}
+                    {:reconciliation/items ["All items must belong to the account being reconciled"]})))
 
 (def ^:private parent-account-context
   (conj basic-context
@@ -188,27 +185,26 @@
                                                  :account "Checking"
                                                  :quantity 700M}]}))
 
-(deftest item-refs-can-reference-items-that-belong-to-children-of-the-account-being-reconciled
+(deftest items-can-reference-items-that-belong-to-children-of-the-account-being-reconciled
   (with-context parent-account-context
     (let [savings (find-account "Savings")
           car (find-account "Car")
           reserve (find-account "Reserve")
-          item-refs (->> *context*
+          items (->> *context*
                          (filter (util/model-type? :transaction))
                          (mapcat :transaction/items)
                          (filter #(or (model= reserve
                                               (:transaction-item/account %))
                                       (model= car
-                                              (:transaction-item/account %))))
-                         (mapv ->item-ref))
+                                              (:transaction-item/account %)))))
           created (assert-created
                     #:reconciliation{:account savings
                                      :end-of-period (t/local-date 2015 1 31)
                                      :status :completed
                                      :balance 300M
-                                     :item-refs item-refs})]
-      (is (= (set item-refs)
-             (set (:reconciliation/item-refs created)))))))
+                                     :items items})]
+      (is (= (set items)
+             (set (:reconciliation/items created)))))))
 
 (def ^:private working-rec-context
   (conj reconciliation-context
@@ -216,7 +212,7 @@
                          :end-of-period (t/local-date 2017 1 1)
                          :balance 447M
                          :status :new
-                         :item-refs [[(t/local-date 2017 1 1)
+                         :items [[(t/local-date 2017 1 1)
                                       1000M]
                                      [(t/local-date 2017 1 2)
                                       500M]
@@ -234,12 +230,11 @@
       #:reconciliation{:account (find-account "Checking")
                        :end-of-period (t/local-date 2017 1 31)
                        :balance 1500M
-                       :item-refs [(->item-ref
-                                    (find-transaction-item
-                                      [(t/local-date 2017 1 1)
-                                       1000M
-                                       "Checking"]))]}
-      {:reconciliation/item-refs ["No item can belong to another reconciliation"]})))
+                       :items [(find-transaction-item
+                                 [(t/local-date 2017 1 1)
+                                  1000M
+                                  "Checking"])]}
+      {:reconciliation/items ["No item can belong to another reconciliation"]})))
 
 (deftest a-working-reconciliation-can-be-updated
   (with-context working-reconciliation-context
@@ -258,13 +253,12 @@
   (with-context working-reconciliation-context
     (let [checking (find-account "Checking")
           previous-rec (find-reconciliation [checking (t/local-date 2017 1 1)])
-          item-ref (->item-ref
-                     (find-transaction-item [(t/local-date 2017 1 3)
-                                             45M
-                                             checking]))
+          item (find-transaction-item [(t/local-date 2017 1 3)
+                                       45M
+                                       checking])
           result (-> (find-reconciliation [checking (t/local-date 2017 1 3)])
                      (assoc :reconciliation/status :completed)
-                     (update-in [:reconciliation/item-refs] conj item-ref)
+                     (update-in [:reconciliation/items] conj item)
                      models/put)]
       (is (comparable? #:reconciliation {:status :completed}
                        result)
@@ -300,14 +294,14 @@
 
 (deftest an-out-of-balance-reconciliation-cannot-be-updated-to-completed
   (with-context working-reconciliation-context
-    (let [item-ref (->item-ref (find-transaction-item [(t/local-date 2017 1 10)
-                                                       53M
-                                                       "Checking"]))]
+    (let [item (find-transaction-item [(t/local-date 2017 1 10)
+                                       53M
+                                       "Checking"])]
       (-> (find-reconciliation ["Checking" (t/local-date 2017 1 3)])
           (assoc :reconciliation/status :completed)
-          (update-in [:reconciliation/item-refs]
+          (update-in [:reconciliation/items]
                      conj
-                     item-ref)
+                     item)
           (assert-invalid {:reconciliation/balance ["Balance must match the calculated balance"]})))))
 
 (deftest a-completed-reconciliation-cannot-be-updated

--- a/test/clj_money/models/transactions_test.clj
+++ b/test/clj_money/models/transactions_test.clj
@@ -958,7 +958,7 @@
                          :end-of-period (t/local-date 2017 1 1)
                          :balance 1000M
                          :status :completed
-                         :item-refs [[(t/local-date 2017 1 1)
+                         :items [[(t/local-date 2017 1 1)
                                       1000M]]}))
 
 (deftest the-quantity-of-a-reconciled-item-cannot-be-changed

--- a/test/clj_money/test_context.clj
+++ b/test/clj_money/test_context.clj
@@ -212,6 +212,7 @@
           (mapcat :transaction/items)
           (filter #(and (model= act (:transaction-item/account %))
                         (= quantity (:transaction-item/quantity %))))
+          (map #(assoc % :transaction/transaction-date transaction-date))
           first))))
 
 (defn find-scheduled-transaction

--- a/test/clj_money/test_context.clj
+++ b/test/clj_money/test_context.clj
@@ -321,9 +321,8 @@
   (let [account (find-account ctx (:reconciliation/account recon))]
     (-> recon
         (assoc :reconciliation/account account)
-        (update-in [:reconciliation/item-refs]
-                   (partial mapv (comp (juxt :id :transaction/transaction-date)
-                                       #(find-transaction-item ctx %)
+        (update-in [:reconciliation/items]
+                   (partial mapv (comp #(find-transaction-item ctx %)
                                        #(conj % account)))))))
 
 (defmethod prepare :budget

--- a/test/clj_money/util_test.cljc
+++ b/test/clj_money/util_test.cljc
@@ -1,6 +1,9 @@
 (ns clj-money.util-test
   (:require #?(:clj [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer [deftest is testing]])
+            #?(:clj [java-time.api :as t]
+               :cljs [cljs-time.core :as t])
+            [clj-money.dates :as dates]
             [clj-money.util :as util]))
 
 (deftest model-typing
@@ -303,3 +306,15 @@
                [[:one 1]
                 [:one 11]
                 [:two 2]]))))
+
+(deftest turn-a-sequence-into-a-range
+  (is (= [1 4]
+         (util/->range [2 4 3 1]))
+      "Integers can be processed")
+  (is (= [(dates/local-date "2020-01-01")
+          (dates/local-date "2020-12-01")]
+         (util/->range [(dates/local-date "2020-01-01")
+                        (dates/local-date "2020-12-01")
+                        (dates/local-date "2020-05-01")]
+                       :compare t/before?))
+      "Integers can be processed"))


### PR DESCRIPTION
The item can be abbreviated with just the `:id` and `:transaction/transaction-date` attributes.