### PR TITLE
Sequential import

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -175,7 +175,7 @@ services:
     restart: on-failure
     ports:
       - 4050:8080
-    command: sh -c "while [ ! -e /init-markers/datomic-schema-complete ]; do echo 'waiting for datomic schema...'; sleep 5s; done && ./bin/console -p '8080' sql '${DATOMIC_NO_DB_URI}'"
+    command: sh -c "while [ ! -e /init-markers/datomic-schema-complete ]; do echo 'waiting for datomic schema...'; sleep 5s; done && ./bin/console -p '8080' sql 'datomic:sql://?jdbc:postgresql://${SQL_HOST}:5432/datomic?user=${SQL_APP_USER}&password=${SQL_APP_PASSWORD}'"
     volumes:
       - type: volume
         source: init-markers

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -116,12 +116,18 @@
           entity
           (models/put updated))))))
 
+(defn- resolve-account-reference
+  ([ctx] #(resolve-account-reference % ctx))
+  ([{:as item :import/keys [account-id]} {:keys [account-ids accounts]}]
+   (assoc item
+          :transaction-item/account
+          (-> account-id account-ids accounts))))
+
 (defn- resolve-account-references
   ([ctx]
    (partial resolve-account-references ctx))
-  ([{:keys [account-ids accounts]} items]
-   (map (fn [{:import/keys [account-id] :as item}]
-          (assoc item :transaction-item/account (-> account-id account-ids accounts)))
+  ([ctx items]
+   (map (resolve-account-reference ctx)
         items)))
 
 (defn- prepare-transaction

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -117,10 +117,10 @@
           (models/put updated))))))
 
 (defn- resolve-account-references
-  [{:keys [account-ids]} items]
+  [{:keys [account-ids accounts]} items]
   (map (fn [{:import/keys [account-id] :as item}]
          (-> item
-             (assoc :transaction-item/account {:id (account-ids account-id)})
+             (assoc :transaction-item/account (-> account-id account-ids accounts))
              purge-import-keys))
        items))
 

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -437,13 +437,14 @@
 
 (defn- apply-transaction-to-accounts
   ([trx] #(apply-transaction-to-accounts % trx))
-  ([accounts {:transaction/keys [items]}]
+  ([accounts {:transaction/keys [items transaction-date]}]
    (->> items
         (map polarize-item-quantity)
         (reduce (fn [acts {:transaction-item/keys [account polarized-quantity]}]
                   (update-in acts
                              [(:id account)]
                              #(-> %
+                                  (dates/push-model-boundary :account/transaction-date-range transaction-date)
                                   (update-in [:account/quantity] + polarized-quantity)
                                   (update-in [:account/value] + polarized-quantity))))
                 accounts))))

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -393,8 +393,8 @@
        (refine-recon-info ctx)
        (resolve-account-reference ctx)
        polarize-item-quantity
-       (propagate-item ctx)
-       purge-import-keys)))
+       purge-import-keys
+       (propagate-item ctx))))
 
 (defmethod import-record* :transaction
   [context transaction]

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -506,7 +506,7 @@
    {:keys [entity]}]
   (let [accounts (models/select
                    (util/model-type
-                     {:id (:id account)}
+                     (select-keys account [:id])
                      :account)
                    {:include-children? true})]
     (models/select
@@ -515,7 +515,7 @@
           {:earliest-date (get-in entity [:entity/transaction-date-range 0])
            :latest-date (get-in entity [:entity/transaction-date-range 1])}
           accounts)
-        :transaction-item/reconciliation (util/->model-ref id)))))
+        :transaction-item/reconciliation {:id id}))))
 
 (defn- process-reconciliation
   [recon {:as ctx :keys [accounts]}]

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -123,13 +123,6 @@
           :transaction-item/account
           (-> account-id account-ids accounts))))
 
-(defn- resolve-account-references
-  ([ctx]
-   (partial resolve-account-references ctx))
-  ([ctx items]
-   (map (resolve-account-reference ctx)
-        items)))
-
 (defn- prepare-transaction
   [transaction {:keys [entity]}]
   (-> transaction
@@ -403,9 +396,9 @@
                          [:transaction/items]
                          (comp #(map (comp purge-import-keys
                                            (propagate-item context)
-                                           polarize-item-quantity)
+                                           polarize-item-quantity
+                                           (resolve-account-reference context))
                                      %)
-                               (resolve-account-references context)
                                (refine-recon-info context)
                                remove-zero-quantity-items))]
       (if (empty? (:transaction/items trx))

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -121,9 +121,7 @@
    (partial resolve-account-references ctx))
   ([{:keys [account-ids accounts]} items]
    (map (fn [{:import/keys [account-id] :as item}]
-          (-> item
-              (assoc :transaction-item/account (-> account-id account-ids accounts))
-              purge-import-keys))
+          (assoc item :transaction-item/account (-> account-id account-ids accounts)))
         items)))
 
 (defn- prepare-transaction
@@ -397,7 +395,8 @@
   (with-fatal-exceptions
     (let [trx (update-in transaction
                          [:transaction/items]
-                         (comp #(map (comp (propagate-item context)
+                         (comp #(map (comp purge-import-keys
+                                           (propagate-item context)
                                            polarize-item-quantity)
                                      %)
                                (resolve-account-references context)

--- a/src/clj_money/import.clj
+++ b/src/clj_money/import.clj
@@ -392,16 +392,15 @@
 (defmethod import-record* :transaction
   [context transaction]
   (with-fatal-exceptions
-    (let [trx (-> transaction
-                  (update-in [:transaction/items]
-                             (comp #(refine-recon-info context %)
-                                   remove-zero-quantity-items))
-                  (update-in [:transaction/items] #(resolve-account-references
-                                                     context
-                                                     %))
-                  (update-in [:transaction/items] #(map (comp (propagate-item context)
-                                                              polarize-item-quantity)
-                                                        %)))]
+    (let [trx (update-in transaction [:transaction/items]
+                         (comp #(map (comp (propagate-item context)
+                                           polarize-item-quantity)
+                                     %)
+                               #(resolve-account-references
+                                  context
+                                  %)
+                               #(refine-recon-info context %)
+                               remove-zero-quantity-items))]
       (if (empty? (:transaction/items trx))
         (do
           (log/warnf "[import] Transaction with no items: %s" trx)

--- a/src/clj_money/progress/redis.clj
+++ b/src/clj_money/progress/redis.clj
@@ -96,11 +96,13 @@
   (let [pattern (build-key opts :processes "*")
         [finished
          warnings
+         failure-reason
          started-at
          completed-at
          keys] (car/wcar redis-opts
                          (car/get (build-key opts :finished))
                          (car/lrange (build-key opts :warnings) 0 -1)
+                         (car/get (build-key opts :failure-reason))
                          (car/get (build-key opts :started-at))
                          (car/get (build-key opts :completed-at))
                          (car/keys pattern))
@@ -121,6 +123,7 @@
                           (assoc-in m k v))
                         {}))
            :warnings warnings
+           :failure-reason failure-reason
            :finished (= "1" finished)
            :started-at started-at
            :completed-at completed-at)))

--- a/src/clj_money/trading.clj
+++ b/src/clj_money/trading.clj
@@ -225,6 +225,12 @@
   [{{:commodity/keys [symbol]} :trade/commodity}]
   (format "Dividend received from %s" symbol))
 
+; we'll either get a fn that gets a meaningful basis, or we just supply
+; random values on the assumption propagation will happen separately
+(defn- random-item-basis [& _]
+  {:transaction-item/balance 0M
+   :transaction-item/index (rand-int Integer/MAX_VALUE)})
+
 (defn- create-dividend-transaction
   "When :dividend? is true, creates the transaction for
   the receipt of the dividend"
@@ -235,7 +241,8 @@
                  entity
                  date]
     :as trade}
-   {:keys [item-basis]}]
+   {:keys [item-basis]
+    :or {item-basis random-item-basis}}]
   (if dividend?
     (if dividend-account
       (let [dividend-basis (item-basis dividend-account)
@@ -260,12 +267,6 @@
       (throw (ex-info "Unable to apply the dividend because a dividend account was not specified"
                       trade)))
     trade))
-
-; we'll either get a fn that gets a meaningful basis, or we just supply
-; random values on the assumption propagation will happen separately
-(defn- random-item-basis [& _]
-  {:transaction-item/balance 0M
-   :transaction-item/index (rand-int Integer/MAX_VALUE)})
 
 (defn- create-purchase-transaction
   "Given a trade map, creates the general currency

--- a/src/clj_money/trading.clj
+++ b/src/clj_money/trading.clj
@@ -739,21 +739,21 @@
     (throw (ex-info "Unable to process transfer without most recent commodity price"
                     {:transfer transfer})))
   (let [value (d/* shares (:price/value most-recent-price))]
-      (assoc transfer
-             :transfer/transaction
-             #:transaction{:entity (:commodity/entity commodity)
-                           :transaction-date date
-                           :description (format "Transfer %s shares of %s"
-                                                shares
-                                                (:commodity/symbol commodity))
-                           :items [#:transaction-item{:action :credit
-                                                      :quantity shares
-                                                      :value value
-                                                      :account from-commodity-account}
-                                   #:transaction-item{:action :debit
-                                                      :quantity shares
-                                                      :value value
-                                                      :account to-commodity-account}]})))
+    (assoc transfer
+           :transfer/transaction
+           #:transaction{:entity (:commodity/entity commodity)
+                         :transaction-date date
+                         :description (format "Transfer %s shares of %s"
+                                              shares
+                                              (:commodity/symbol commodity))
+                         :items [#:transaction-item{:action :credit
+                                                    :quantity shares
+                                                    :value value
+                                                    :account from-commodity-account}
+                                 #:transaction-item{:action :debit
+                                                    :quantity shares
+                                                    :value value
+                                                    :account to-commodity-account}]})))
 
 (defn- put-transfer
   [{:transfer/keys [transaction

--- a/test/clj_money/import_test.clj
+++ b/test/clj_money/import_test.clj
@@ -440,8 +440,8 @@
             "The 401k account is tagged as a trading account")
         (is (= 0M (:account/quantity four-oh-one-k))
             "All shares have been transfered out of 401k")
-        (is (= 590M (:account/quantity ira))
-            "Shares have been transfered into IRA"))
+        (is (= 591M (:account/quantity ira))
+            "The IRA quantity reflects the sale proceeds and cash in lieu"))
 
       (testing "transactions"
         (let [ira-aapl (models/find-by #:account{:parent ira

--- a/test/clj_money/import_test.clj
+++ b/test/clj_money/import_test.clj
@@ -84,22 +84,30 @@
                :type :asset
                :commodity usd
                :quantity 1810M
-               :value 1810M}
+               :value 1810M
+               :transaction-date-range [(t/local-date 2015 1 1)
+                                        (t/local-date 2015 1 15)]}
      #:account{:name "Credit Card"
                :type :liability
                :commodity usd
                :quantity 100M
-               :value 100M}
+               :value 100M
+               :transaction-date-range [(t/local-date 2015 1 18)
+                                        (t/local-date 2015 1 18)]}
      #:account{:name "Groceries"
                :type :expense
                :commodity usd
                :quantity 290M
-               :value 290M}
+               :value 290M
+               :transaction-date-range [(t/local-date 2015 1 4)
+                                        (t/local-date 2015 1 18)]}
      #:account{:name "Salary"
                :type :income
                :commodity usd
                :quantity 2000M
-               :value 2000M}]))
+               :value 2000M
+               :transaction-date-range [(t/local-date 2015 1 1)
+                                        (t/local-date 2015 1 15)]}]))
 
 (defn- execute-import
   [imp]

--- a/test/clj_money/import_test.clj
+++ b/test/clj_money/import_test.clj
@@ -217,11 +217,7 @@
         (is (= 6 (expect :transaction))
             "Expectation is given for 6 transactions")
         (is (= 6 (increment :transaction))
-            "Transaction count is incremented 6 times")
-        (is (= 4 (expect :propagation))
-            "Expectation is given for 4 propagations")
-        (is (= 4 (increment :propagation))
-            "Propagation count is incremented 4 times")))))
+            "Transaction count is incremented 6 times")))))
 
 (deftest halt-on-failure
   (with-context gnucash-context

--- a/test/clj_money/progress/redis_test.clj
+++ b/test/clj_money/progress/redis_test.clj
@@ -198,6 +198,7 @@
                                       :completed 2
                                       :started-at "2020-01-01T00:00:00Z"
                                       :completed-at "2020-01-01T00:00:00Z"}}
+            :failure-reason nil
             :warnings ["Something not too bad"]
             :finished true
             :started-at "2020-01-01T00:00:00Z"


### PR DESCRIPTION
Instead of importing all transactions and the propagating roll-up values, calculate the roll-up values as we go. (This requires that the transactions be imported in order by date.)