### PR TITLE
Propagate shares owned from lots to commodities

### DIFF
--- a/resources/datomic/schema/commodity.edn
+++ b/resources/datomic/schema/commodity.edn
@@ -31,6 +31,7 @@
  {:db/ident :commodity/shares-owned
   :db/valueType :db.type/bigdec
   :db/cardinality :db.cardinality/one
+  :db/noHistory true
   :db/doc "The total shares currently owned across all lots for this commodity"}
  {:db/ident :price-config/enabled
   :db/valueType :db.type/boolean

--- a/resources/datomic/schema/commodity.edn
+++ b/resources/datomic/schema/commodity.edn
@@ -28,6 +28,10 @@
   :db/valueType :db.type/ref
   :db/cardinality :db.cardinality/one
   :db/doc "The entity that tracks this commodity"}
+ {:db/ident :commodity/shares-owned
+  :db/valueType :db.type/bigdec
+  :db/cardinality :db.cardinality/one
+  :db/doc "The total shares currently owned across all lots for this commodity"}
  {:db/ident :price-config/enabled
   :db/valueType :db.type/boolean
   :db/cardinality :db.cardinality/one

--- a/resources/migrations/20260410000000_add_shares_owned_to_commodity.down.sql
+++ b/resources/migrations/20260410000000_add_shares_owned_to_commodity.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.commodity
+  DROP COLUMN shares_owned;

--- a/resources/migrations/20260410000000_add_shares_owned_to_commodity.up.sql
+++ b/resources/migrations/20260410000000_add_shares_owned_to_commodity.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE public.commodity
+  ADD COLUMN shares_owned numeric(19,6) NOT NULL DEFAULT 0;
+
+UPDATE public.commodity c
+SET shares_owned = (
+  SELECT COALESCE(SUM(l.shares_owned), 0)
+  FROM public.lot l
+  WHERE l.commodity_id = c.id
+    AND l.shares_owned > 0
+);

--- a/src/clj_money/api/commodities.clj
+++ b/src/clj_money/api/commodities.clj
@@ -40,27 +40,11 @@
                (fetch-current-price %))
        commodities))
 
-(defn- append-shares-owned
-  [commodities]
-  (if (seq commodities)
-    (let [lots (->> (entities/select #:lot{:commodity [:in (map util/->entity-ref commodities)]
-                                         :shares-owned [:> 0]})
-                    (group-by (comp :id :lot/commodity))
-                    (map #(update-in % [1] (fn [lots]
-                                             (->> lots
-                                                  (map :lot/shares-owned)
-                                                  (reduce + 0M)))))
-                    (into {}))]
-      (map #(assoc % :lot/shares-owned (get-in lots [(:id %)] 0M))
-           commodities))
-    commodities))
-
 (defn- index
   [req]
   (->> (entities/select (extract-criteria req)
                       {:sort [:commodity/symbol]})
        append-current-prices
-       append-shares-owned
        api/response))
 
 (defn- find-and-authorize

--- a/src/clj_money/commodities.cljc
+++ b/src/clj_money/commodities.cljc
@@ -28,7 +28,6 @@
 (defn has-shares?
   "Returns true if the given commodity either currently held
   in an investment account, or if it is a currency."
-  [{:lot/keys [shares-owned]
-    :commodity/keys [type]}]
+  [{:commodity/keys [shares-owned type]}]
   (or (= :currency type)
-      (< 0M shares-owned)))
+      (< 0M (or shares-owned 0M))))

--- a/src/clj_money/entities/commodities.clj
+++ b/src/clj_money/entities/commodities.clj
@@ -53,6 +53,7 @@
 (s/def :commodity/type #{:currency :stock :fund})
 (s/def :commodity/price-date-range (s/nilable (s/tuple dates/local-date? dates/local-date?)))
 (s/def :commodity/exchange (s/nilable #{:amex :nasdaq :nyse :otc}))
+(s/def :commodity/shares-owned decimal?)
 
 (s/def :price-config/enabled boolean?)
 (s/def :commodity/price-config (s/keys :req [:price-config/enabled]))
@@ -64,7 +65,8 @@
                        :commodity/entity]
                  :opt [:commodity/price-config
                        :commodity/exchange
-                       :commodity/price-date-range])
+                       :commodity/price-date-range
+                       :commodity/shares-owned])
          name-is-unique?
          symbol-is-unique?
          exchange-is-satisfied?))
@@ -72,6 +74,22 @@
 (defmethod entities/before-validation :commodity
   [comm]
   (update-in comm [:commodity/price-config] #(or % {:price-config/enabled false})))
+
+(defn with-shares-owned
+  "Returns the commodity with :commodity/shares-owned set to the
+  sum of shares-owned across all lots for that commodity."
+  [commodity]
+  (let [shares (->> (entities/select
+                      #:lot{:commodity (util/->entity-ref commodity)
+                            :shares-owned [:> 0]})
+                    (map :lot/shares-owned)
+                    (reduce + 0M))]
+    (assoc commodity :commodity/shares-owned shares)))
+
+(defn recalc-shares-owned
+  "Recalculates and saves the shares-owned total for a commodity."
+  [commodity]
+  (entities/put (with-shares-owned commodity)))
 
 (defn- assign-default-commodity
   [entity]
@@ -86,6 +104,8 @@
 (defn propagate-all
   [entity _opts]
   {:pre [entity]}
+  (doseq [commodity (entities/select {:commodity/entity entity})]
+    (recalc-shares-owned commodity))
   (if (get-in entity [:entity/settings
                       :settings/default-commodity])
     entity

--- a/src/clj_money/entities/lots.clj
+++ b/src/clj_money/entities/lots.clj
@@ -2,7 +2,9 @@
   (:require [clojure.spec.alpha :as s]
             [java-time.api :as t]
             [dgknght.app-lib.validation :as v]
-            [clj-money.entities :as entities]))
+            [clj-money.entities :as entities]
+            [clj-money.entities.commodities :as commodities]
+            [clj-money.entities.propagation :as prop]))
 
 (defn- asset-account?
   [account]
@@ -23,3 +25,10 @@
                                   :lot/purchase-price
                                   :lot/shares-purchased]
                             :opt [:lot/shares-owned]))
+
+(defmethod prop/propagate :lot
+  [[before after]]
+  (when-let [commodity (some-> (or after before)
+                               :lot/commodity
+                               (entities/find))]
+    [(commodities/with-shares-owned commodity)]))

--- a/src/clj_money/entities/schema.cljc
+++ b/src/clj_money/entities/schema.cljc
@@ -100,6 +100,8 @@
                :type :keyword}
               {:id :price-config
                :type :map}
+              {:id :shares-owned
+               :type :decimal}
               {:id :price-date-range
                :type :tuple
                :transient? true}}


### PR DESCRIPTION
## Summary

- Adds `shares_owned` column to the commodity table (SQL migration + Datomic schema)
- Propagates the sum of lot `shares_owned` onto the commodity record whenever a lot is saved or deleted, using a new `prop/propagate :lot` defmethod
- `propagate-all` for commodities recalculates `shares_owned` for every commodity in the entity during full propagation
- Removes the slow `append-shares-owned` query from the commodities API index handler — the value is now stored on the commodity record directly

## Test plan

- [x] `lein ptest clj-money.trading-test` — 15/15 pass
- [x] `lein ptest clj-money.commodities-test` — 2/2 pass
- [x] `lein ptest clj-money.api.commodities-test clj-money.api.trading-test` — 21/21 pass
- [x] `clj-kondo --lint src` — 0 errors, 0 warnings
- [ ] Run `lein migrate` against the production DB before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)