### PR TITLE
fix login form persisting after successful authentication

### DIFF
--- a/src/clj_money/app.cljs
+++ b/src/clj_money/app.cljs
@@ -15,13 +15,17 @@
               e))))
 
 (defn- receive-entities
-  [[entity :as entities]]
+  [[entity :as entities] on-complete]
   (state/set-entities entities)
   (if entity
-    (load-pending-count)
+    (do
+      (load-pending-count)
+      (when on-complete (on-complete)))
     (accountant/navigate! "/entities")))
 
-(defn fetch-entities []
-  (+busy)
-  (entities/select :callback -busy
-                   :on-success receive-entities))
+(defn fetch-entities
+  ([] (fetch-entities nil))
+  ([on-complete]
+   (+busy)
+   (entities/select :callback -busy
+                    :on-success #(receive-entities % on-complete))))

--- a/src/clj_money/app.cljs
+++ b/src/clj_money/app.cljs
@@ -15,17 +15,17 @@
               e))))
 
 (defn- receive-entities
-  [[entity :as entities] on-complete]
-  (state/set-entities entities)
-  (if entity
-    (do
-      (load-pending-count)
-      (when on-complete (on-complete)))
-    (accountant/navigate! "/entities")))
+  [on-complete]
+  (fn [[entity :as entities]]
+    (state/set-entities entities)
+    (if entity
+      (do
+        (load-pending-count)
+        (when on-complete (on-complete)))
+      (accountant/navigate! "/entities"))))
 
 (defn fetch-entities
-  ([] (fetch-entities nil))
-  ([on-complete]
-   (+busy)
-   (entities/select :callback -busy
-                    :on-success #(receive-entities % on-complete))))
+  [& {:keys [on-complete]}]
+  (+busy)
+  (entities/select :callback -busy
+                   :on-success (receive-entities on-complete)))

--- a/src/clj_money/views/users.cljs
+++ b/src/clj_money/views/users.cljs
@@ -18,13 +18,14 @@
 (defn- authenticate
   [page-state]
   (+busy)
-  (users/authenticate (:credentials @page-state)
-                      :callback -busy
-                      :on-success (fn [{:keys [user auth-token]}]
-                                    (swap! app-state assoc
-                                           :current-user user
-                                           :auth-token auth-token)
-                                    (fetch-entities #(accountant/navigate! "/")))))
+  (users/authenticate
+    (:credentials @page-state)
+    :callback -busy
+    :on-success (fn [{:keys [user auth-token]}]
+                  (swap! app-state assoc
+                         :current-user user
+                         :auth-token auth-token)
+                  (fetch-entities :on-complete #(accountant/navigate! "/")))))
 
 (defn- login []
   (let [page-state (r/atom {:credentials {}})

--- a/src/clj_money/views/users.cljs
+++ b/src/clj_money/views/users.cljs
@@ -1,6 +1,7 @@
 (ns clj-money.views.users
   (:require [secretary.core :as secretary :include-macros true]
             [reagent.core :as r]
+            [accountant.core :as accountant]
             [dgknght.app-lib.dom :refer [set-focus]]
             [dgknght.app-lib.forms :as forms]
             [dgknght.app-lib.forms-validation :as v]
@@ -23,7 +24,7 @@
                                     (swap! app-state assoc
                                            :current-user user
                                            :auth-token auth-token)
-                                    (fetch-entities))))
+                                    (fetch-entities #(accountant/navigate! "/")))))
 
 (defn- login []
   (let [page-state (r/atom {:credentials {}})


### PR DESCRIPTION
After a successful login with entities already present, receive-entities only loaded the pending count but never navigated away from /login. Add an optional on-complete callback to fetch-entities so the login handler can navigate to / once entities are loaded.