### PR TITLE
Restore use of clojure.core/abs

### DIFF
--- a/src/clj_money/decimal.cljc
+++ b/src/clj_money/decimal.cljc
@@ -101,8 +101,8 @@
            ([^java.math.BigDecimal n places]
             (.setScale n places BigDecimal/ROUND_HALF_UP))))
 
-#?(:cljs (defn abs [n] (decimal/abs n))
-   :clj  (defn abs [^java.math.BigDecimal n] (.abs n)))
+#?(:cljs (def abs decimal/abs)
+   :clj  (def abs core/abs))
 
 (def ^:private parsers
    [{:pattern #".*"

--- a/src/clj_money/import/gnucash.clj
+++ b/src/clj_money/import/gnucash.clj
@@ -1,5 +1,4 @@
 (ns clj-money.import.gnucash
-  (:refer-clojure :exclude [abs])
   (:require [clojure.tools.logging :as log]
             [clojure.pprint :refer [pprint]]
             [clojure.java.io :as io]
@@ -630,10 +629,6 @@
         (:sell actions)               :sell
         (:buy actions)                :purchase
         (:split actions)              :split))))
-
-(defn- abs
-  [^BigDecimal value]
-  (.abs value))
 
 (defn- abs-items
   ([transaction]


### PR DESCRIPTION
## Summary

- Replaced the custom CLJ `abs` implementation in `clj-money.decimal` with an alias to `clojure.core/abs` (supported for BigDecimal since Clojure 1.11)
- Replaced the custom CLJS `abs` implementation with an alias to `dgknght.app-lib.decimal/abs` (needed to correctly handle Decimal.js objects)
- Removed the private `abs` function from `clj-money.import.gnucash` and its `(:refer-clojure :exclude [abs])`, letting `clojure.core/abs` be used directly

## Test plan

- [x] `lein ptest clj-money.decimal-test` — passes
- [x] `lein ptest clj-money.accounts-test clj-money.transactions-test clj-money.receipts-test` — passes
- [x] `lein ptest clj-money.trading-test` — passes
- [x] `clj-kondo --lint src` — 0 errors, 0 warnings

Closes #106

🤖 Generated with [Claude Code](https://claude.ai/claude-code)