### PR TITLE
Use entity transaction date ranges in valuation queries

### DIFF
--- a/src/clj_money/reports.clj
+++ b/src/clj_money/reports.clj
@@ -111,11 +111,14 @@
         trading-account-ids (->> accounts
                                  (filter (system-tagged? :trading))
                                  (map :id))
+        [earliest-date] (:entity/transaction-date-range entity)
         lots (when (seq trading-account-ids)
                (group-by (juxt (comp :id :lot/account)
                                (comp :id :lot/commodity))
                          (entities/select {:lot/account [:in trading-account-ids]
-                                           :lot/purchase-date [:<= as-of]})))
+                                           :lot/purchase-date [:between
+                                                               earliest-date
+                                                               as-of]})))
         lot-items (when (seq lots)
                     (group-by (comp :id :lot-item/lot)
                               (entities/select
@@ -123,7 +126,9 @@
                                   {:lot-item/lot [:in (->> (vals lots)
                                                            (mapcat identity)
                                                            (mapv :id))]
-                                   :transaction/transaction-date [:<= as-of]}
+                                   :transaction/transaction-date [:between
+                                                                  earliest-date
+                                                                  as-of]}
                                   :lot-item))))
         prices (atom {})]
     (reify accounts/ValuationData


### PR DESCRIPTION
## Summary

- In `valuation-data`, the `lots` and `lot-items` queries previously used only an upper bound (`[:<= as-of]`) on their date fields
- Added the entity's `transaction-date-range` earliest date as a lower bound, converting to `[:between earliest-date as-of]` in both queries
- All other report queries (income statement, balance sheet, budget) already flow through `balance-data` which correctly uses `entity/transaction-date-range` via `find-in-chunks`

**SQL**: Benefits from `ix_transaction_transaction_date_entity_id` (`transaction_date, entity_id`) — a bounded range scan is more precise than an open-ended `<= upper` scan.

**Datomic**: Tighter AVET index range bounds reduce traversal when resolving `transaction/transaction-date` and `lot/purchase-date`.

The change is safe: `valuation-data` is only called from `valuate-accounts`, which already guards on `entity/transaction-date-range` being set.

## Test plan

- [x] `lein ptest clj-money.reports-test` — 11 tests, 17 assertions, 0 failures
- [x] `clj-kondo --lint src/clj_money/reports.clj` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)