### PR TITLE
Use debounce from app-lib

### DIFF
--- a/src/clj_money/components.cljs
+++ b/src/clj_money/components.cljs
@@ -4,13 +4,11 @@
             [cljs.core.async :as a :refer [chan <! >! go go-loop close!]]
             [dgknght.app-lib.core :refer [present?
                                           presence]]
+            [dgknght.app-lib.dom :refer [debounce]]
             [dgknght.app-lib.web :refer [format-date-time
                                          format-decimal]]
             [clj-money.icons :as icons]
-            [clj-money.state :refer [busy?]]
-            [clj-money.util
-             :as util
-             :refer [debounce]]))
+            [clj-money.state :refer [busy?]]))
 
 (defn load-on-scroll
   "Adds load-on-scroll behavior to a component.
@@ -49,7 +47,7 @@
                                                                   fully-loaded-content
                                                                   partially-loaded-content))
                                                250))))) ; a callback would be nice, but complicated. Let's just show a brief message)))
-        debounced-scroll-listener (debounce 200 scroll-listener)
+        debounced-scroll-listener (debounce scroll-listener 200)
         attach-scroll-listener (fn [this]
                                  (let [targetElem (if target
                                                     (.getElementById js/document target)

--- a/src/clj_money/util.cljc
+++ b/src/clj_money/util.cljc
@@ -209,17 +209,6 @@
            {}
            coll)))
 
-#?(:cljs
-   (defn debounce
-     [timeout f]
-     (let [t (atom nil)]
-       (fn [& args]
-         (when @t (js/clearTimeout @t))
-         (reset! t (js/setTimeout (fn []
-                                    (reset! t nil)
-                                    (apply f args))
-                                  timeout))))))
-
 (defn make-series
   "Given a template and a list of maps, create a sequence
   of the template merged with each map in the list"

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -11,7 +11,8 @@
             [dgknght.app-lib.web :refer [format-date
                                          format-decimal ]]
             [dgknght.app-lib.inflection :refer [humanize]]
-            [dgknght.app-lib.dom :refer [set-focus
+            [dgknght.app-lib.dom :refer [debounce
+                                         set-focus
                                          key-code
                                          shift-key?]]
             [dgknght.app-lib.html :refer [space
@@ -27,7 +28,7 @@
                                      +busy
                                      -busy]]
             [clj-money.dnd :as dnd]
-            [clj-money.util :as util :refer [debounce id=]]
+            [clj-money.util :as util :refer [id=]]
             [clj-money.dates :as dates]
             [clj-money.commodities :as cmdts]
             [clj-money.accounts :as accounts :refer [find-by-path
@@ -229,12 +230,12 @@
                               :color "var(--white)"
                               :cursor :copy})
       :on-drag-leave (debounce
-                       100
                        #(swap! page-state
                                update-in
                                [:item-row-styles]
                                dissoc
-                               (:id item)))
+                               (:id item))
+                       100)
       :on-drag-over #(.preventDefault %)
       :on-drop #(handle-item-row-drop item % page-state)
       :style (get-in styles [(:id item)])}


### PR DESCRIPTION
## Summary

- Removes the local `debounce` implementation from `clj-money.util`
- Updates `components.cljs` and `views/transactions.cljs` to use `dgknght.app-lib.dom/debounce` instead
- Updates call sites to match app-lib's argument order: `(debounce f timeout)` vs the old `(debounce timeout f)`

## Test plan

- [ ] Load the transactions view and verify drag-and-drop row highlighting works (debounce on `:on-drag-leave`)
- [ ] Scroll a long transaction list and verify infinite scroll still loads more items (debounce on scroll listener in `load-on-scroll`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)