### PR TITLE
Strip commas before parsing decimal input

### DIFF
--- a/src/clj_money/decimal.cljc
+++ b/src/clj_money/decimal.cljc
@@ -104,18 +104,6 @@
 #?(:cljs (def abs decimal/abs)
    :clj  (def abs core/abs))
 
-(def ^:private parsers
-   [{:pattern #".*"
-     :fn math/eval}
-    {:pattern #"(\d+)(?:,(\d+))*"
-     :fn #(->> %
-                 (drop 1)
-                 (string/join "")
-                 (d))}])
-
 (defn parse
    [s]
-   (some (fn [{:keys [pattern fn]}]
-            (when-let [match (re-find pattern s)]
-               (fn match)))
-         parsers))
+   (math/eval (string/replace s "," "")))

--- a/test/clj_money/decimal_test.cljc
+++ b/test/clj_money/decimal_test.cljc
@@ -10,5 +10,7 @@
       "A ratio is parsed into a decimal")
   (is (= (d/d 5000) (d/parse "5,000"))
       "A number formatted with commas is parsed into a decimal")
+  (is (= (d/d 1000.0) (d/parse "1,000.0"))
+      "A decimal formatted with commas is parsed into a decimal")
   (is (= (d/d 2) (d/parse "1+1"))
       "A basic mathematical expression is calculated"))


### PR DESCRIPTION
## Summary

- Fixes decimal input parsing when the user types values like `1,000.0` in price fields
- The previous `parsers` vector had a dead second entry — the first `#".*"` pattern always matched, so the comma-stripping path never ran
- Fix: remove commas from the string up-front with `string/replace` before delegating to `math/eval`

Closes #76 (Trello: Commas should be ignored when parsing decimal values)

## Test plan

- [ ] Run `lein test clj-money.decimal-test` — all 4 assertions pass
- [ ] Manually: select a commodity → open prices list → Add → enter date and price `1,000.0` → Save → price should be recorded as `1000.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)