### PR TITLE
Fix race condition in delete-many causing flaky trading tests

### DIFF
--- a/src/clj_money/entities.clj
+++ b/src/clj_money/entities.clj
@@ -286,16 +286,20 @@
 
 (defn delete-many
   ([entities] (delete-many {} entities))
-  ([{:keys [out-chan]} entities]
+  ([{:keys [out-chan ctrl-chan]} entities]
    {:pre [(seq (filter identity entities))]}
    (let [result (->> entities
                      (map before-delete)
                      (db/delete (db/storage)))]
      (when out-chan
+       (when ctrl-chan
+         (a/offer! ctrl-chan :start))
        (a/go
          (->> entities
               (map #(vector % nil))
-              (a/onto-chan!! out-chan))))
+              (a/onto-chan!! out-chan))
+         (when ctrl-chan
+           (a/>! ctrl-chan :finish))))
      result)))
 
 (defn delete


### PR DESCRIPTION
## Summary

- `delete-many` was not signaling `ctrl-chan` with `:start`/`:finish` like `emit-changes` (used by `put-many`) does
- `with-propagation` uses those signals to track pending goroutines; without them it closed `out-chan` before the deletion goroutine ran
- This silently dropped the account-balance propagation changes, causing `undo-a-purchase` to intermittently see stale balances

## Test plan

- [x] `lein ptest clj-money.trading-test` — ran 5 times, 0 failures each run (was intermittently failing before)
- [x] `clj-kondo --lint src/clj_money/entities.clj` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)