### PR TITLE
Remove unused reagent-forms dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,6 @@
                  [org.clojure/google-closure-library "0.0-20230227-c7c0a541"]
                  [secretary "1.2.3" :exclusions [com.google.javascript/closure-compiler
                                                  org.clojure/tools.reader]]
-                 [reagent-forms "0.5.41"]
                  [reagent-utils "0.3.8"]
                  [org.clojure/clojurescript "1.11.132" :exclusions [org.clojure/tools.reader]]
                  [com.google.guava/guava "31.0.1-jre" :exclusions [com.google.code.findbugs/jsr305


### PR DESCRIPTION
## Summary
- Removes the `reagent-forms` library from `project.clj` — it was declared as a dependency but never imported or used in any source file.

## Test plan
- [ ] Verify ClojureScript build still compiles successfully (`lein fig:build`)
- [ ] Smoke-test the UI to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)