### PR TITLE
Fix lein routes command

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -186,7 +186,7 @@
             "import-user-tags"      ["run" "-m" "clj-money.tasks/import-user-tags"]
             "er-diagram"            ["run" "-m" "clj-money.tasks/er-diagram"]
             "re-index"              ["run" "-m" "clj-money.tasks/re-index"]
-            "routes"                ["run" "-m" "clj-money.web.server/print-routes"]
+            "routes"                ["run" "-m" "clj-money.repl/print-routes"]
             "fig:prod"              ["run" "-m" "figwheel.main" "-O" "advanced" "-bo" "prod"]
             "fig:build"             ["trampoline" "run" "-m" "figwheel.main" "-b" "dev" "-r"]
             "fig:min"               ["run" "-m" "figwheel.main" "-O" "advanced" "-bo" "dev"]

--- a/src/clj_money/repl.clj
+++ b/src/clj_money/repl.clj
@@ -3,7 +3,6 @@
             [clojure.java.io :as io]
             [clojure.string :as string]
             [reitit.core :as reitit]
-            [reitit.ring :as ring]
             [clj-money.web.server :as s]
             [clj-money.entities :as entities]
             [clj-money.util :as util]
@@ -13,9 +12,7 @@
 
 (defn print-routes []
   (doseq [[method path handler]
-          (->> (-> s/app
-                   ring/get-router
-                   reitit/compiled-routes)
+          (->> (reitit/compiled-routes s/router)
                (mapcat (fn [[path opts]]
                          (->> [:get :post :put :patch :delete]
                               (map (juxt identity opts))

--- a/src/clj_money/web/server.clj
+++ b/src/clj_money/web/server.clj
@@ -145,74 +145,77 @@
       (oauth2/wrap-oauth2 handler profiles)
       handler)))
 
+(def router
+  (ring/router ["/" {:middleware [otel/wrap-otel]}
+                apps/routes
+                ["auth/google/done"
+                 {:middleware [:site
+                               wrap-merge-params
+                               wrap-request-logging]
+                  :get {:handler google-auth/redirect-handler}}]
+                ["auth/github/done"
+                 {:middleware [:site
+                               wrap-merge-params
+                               wrap-request-logging]
+                  :get {:handler github-auth/redirect-handler}}]
+                ["app/" {:middleware [:site
+                                      :wrap-format
+                                      wrap-merge-params
+                                      wrap-parse-id-params
+                                      :authentication
+                                      wrap-request-logging]}
+                 images/routes]
+                ["oapi/" {:middleware [:api
+                                       :wrap-format
+                                       wrap-decimals
+                                       wrap-merge-params
+                                       wrap-parse-id-params
+                                       wrap-exceptions
+                                       wrap-request-logging]}
+                 users-api/unauthenticated-routes
+                 invitations-api/unauthenticated-routes]
+                ["api/" {:middleware [:api
+                                      :wrap-format
+                                      wrap-decimals
+                                      wrap-merge-params
+                                      wrap-parse-id-params
+                                      :authentication
+                                      wrap-exceptions
+                                      wrap-request-logging]}
+                 users-api/routes
+                 entities-api/routes
+                 commodities-api/routes
+                 accounts-api/routes
+                 transactions-api/routes
+                 att-api/routes
+                 budgets-api/routes
+                 budget-items-api/routes
+                 imports-api/routes
+                 prices-api/routes
+                 lots-api/routes
+                 lot-notes-api/routes
+                 audit-api/routes
+                 recs-api/routes
+                 reports-api/routes
+                 trading-api/routes
+                 transaction-items-api/routes
+                 sched-trans-api/routes
+                 invitations-api/routes]]
+               {:conflicts (fn [conflicts]
+                             (log/warnf "The application has conflicting routes: %s"
+                                        (format-exception :path-conflicts nil conflicts)))
+                ::middleware/registry {:site (wrap-site)
+                                       :api [wrap-defaults
+                                             (-> api-defaults
+                                                 (assoc-in [:params :multipart] true)
+                                                 (assoc-in [:security :anti-forgery] false))]
+                                       :wrap-format wrap-format
+                                       :authentication [api/wrap-authentication
+                                                        {:authenticate-fn find-user-by-auth-token}]}}))
+
 (def app
   (-> (ring/ring-handler
-        (ring/router ["/" {:middleware [otel/wrap-otel]}
-                      apps/routes
-                      ["auth/google/done"
-                       {:middleware [:site
-                                     wrap-merge-params
-                                     wrap-request-logging]
-                        :get {:handler google-auth/redirect-handler}}]
-                      ["auth/github/done"
-                       {:middleware [:site
-                                     wrap-merge-params
-                                     wrap-request-logging]
-                        :get {:handler github-auth/redirect-handler}}]
-                      ["app/" {:middleware [:site
-                                            :wrap-format
-                                            wrap-merge-params
-                                            wrap-parse-id-params
-                                            :authentication
-                                            wrap-request-logging]}
-                       images/routes]
-                      ["oapi/" {:middleware [:api
-                                             :wrap-format
-                                             wrap-decimals
-                                             wrap-merge-params
-                                             wrap-parse-id-params
-                                             wrap-exceptions
-                                             wrap-request-logging]}
-                       users-api/unauthenticated-routes
-                       invitations-api/unauthenticated-routes]
-                      ["api/" {:middleware [:api
-                                            :wrap-format
-                                            wrap-decimals
-                                            wrap-merge-params
-                                            wrap-parse-id-params
-                                            :authentication
-                                            wrap-exceptions
-                                            wrap-request-logging]}
-                       users-api/routes
-                       entities-api/routes
-                       commodities-api/routes
-                       accounts-api/routes
-                       transactions-api/routes
-                       att-api/routes
-                       budgets-api/routes
-                       budget-items-api/routes
-                       imports-api/routes
-                       prices-api/routes
-                       lots-api/routes
-                       lot-notes-api/routes
-                       audit-api/routes
-                       recs-api/routes
-                       reports-api/routes
-                       trading-api/routes
-                       transaction-items-api/routes
-                       sched-trans-api/routes
-                       invitations-api/routes]]
-                 {:conflicts (fn [conflicts]
-                               (log/warnf "The application has conflicting routes: %s"
-                                          (format-exception :path-conflicts nil conflicts)))
-                  ::middleware/registry {:site (wrap-site)
-                                         :api [wrap-defaults
-                                               (-> api-defaults
-                                                   (assoc-in [:params :multipart] true)
-                                                   (assoc-in [:security :anti-forgery] false))]
-                                         :wrap-format wrap-format
-                                         :authentication [api/wrap-authentication
-                                                          {:authenticate-fn find-user-by-auth-token}]}})
+        router
         (ring/routes
           (ring/create-resource-handler {:path "/"})
           apps/spa-fallback


### PR DESCRIPTION
## Summary

- Fixed wrong namespace in `project.clj` alias: `clj-money.web.server/print-routes` → `clj-money.repl/print-routes` (the function was never in `server.clj`)
- Extracted the reitit `ring/router` call to a public `router` var in `server.clj`; `ring/get-router` reads handler metadata which is stripped by the `wrap-session`/`wrap-params` wrappers around `app`, so calling it on `app` always returned `nil`
- Updated `print-routes` in `repl.clj` to call `reitit/compiled-routes` directly on `s/router` and removed the now-unused `reitit.ring` require

## Test plan

- [ ] Run `lein routes` and confirm it prints the route table without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)