### PR TITLE
Fix import start clearing current entity and crashing accounts view

### DIFF
--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -1087,12 +1087,13 @@
 
 (defn- load-commodities
   [page-state]
-  (+busy)
-  (commodities/select {}
-                      :on-success #(swap! page-state
-                                          assoc
-                                          :commodities (index-by :id %))
-                      :callback -busy))
+  (when @current-entity
+    (+busy)
+    (commodities/select {}
+                        :on-success #(swap! page-state
+                                            assoc
+                                            :commodities (index-by :id %))
+                        :callback -busy)))
 
 (defn- account-filter
   [page-state]

--- a/src/clj_money/views/imports.cljs
+++ b/src/clj_money/views/imports.cljs
@@ -307,7 +307,7 @@
 (defn- start-after-save
   [page-state]
   (fn [result]
-    (state/add-entity (:import/entity result))
+    (state/add-entity (:entity result))
     (reset! auto-refresh true)
     (swap! page-state #(-> %
                            (dissoc :import-data)


### PR DESCRIPTION
## Summary

- `start-after-save` was reading `(:import/entity result)` from the API response, but the create-import endpoint returns `{:entity ... :import ...}` — so `:import/entity` was always nil
- Calling `state/add-entity nil` set `current-entity` to nil, which collapsed the nav bar to just the logout button (appearing as "logged-out navigation")
- Added a guard in `load-commodities` so it skips the API call when `current-entity` is nil, preventing the path assertion error on page load / after entity is cleared

## Test plan

- [ ] Create a new import — verify the nav bar still shows authenticated items after the import starts
- [ ] Open `/accounts` immediately on page load (before entities are fetched) — no assertion error in the console
- [ ] Existing import tests still pass (`lein test clj-money.api.imports-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)