### PR TITLE
Fix verticalPadding React DOM prop warning in fill-remaining-height

### DIFF
--- a/src/clj_money/components.cljs
+++ b/src/clj_money/components.cljs
@@ -142,7 +142,7 @@
        (fn [attrs & children]
          (when-let [p (:vertical-padding attrs)]
            (reset! padding p))
-         (into [:div (merge attrs
+         (into [:div (merge (dissoc attrs :vertical-padding)
                             {:ref #(reset! node-ref %)
                              :style (merge (:style attrs)
                                            (when @height


### PR DESCRIPTION
## Summary

- `fill-remaining-height` was passing the full `attrs` map to the underlying `<div>`, including `:vertical-padding`
- React 18 warns when it sees an unrecognized prop on a DOM element (`verticalPadding`)
- Fix: `dissoc :vertical-padding` from attrs before merging into the div props

## Test plan

- [ ] Open an account's transactions view and confirm the `verticalPadding` React warning is gone from the browser console
- [ ] Confirm the height calculation still works correctly (content fills remaining viewport height)

🤖 Generated with [Claude Code](https://claude.com/claude-code)