### PR TITLE
Reload lots and prices after commodity purchase

### DIFF
--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -702,7 +702,9 @@
                                        (filter (id= account))
                                        first)]
                       (swap! page-state assoc :view-account updated)
-                      (trns/reset-item-loading page-state))
+                      (if (system-tagged? updated :tradable)
+                        (load-tradable-account page-state)
+                        (trns/reset-item-loading page-state)))
                     accounts))))
 
 (defn- post-transaction-save


### PR DESCRIPTION
## Summary
- After saving a trade, `refresh-accounts` fetches updated account data from the server (which includes the newly-extended `transaction-date-range`).
- Previously, for tradable accounts the callback only updated `view-account` — it never reloaded lots or prices, leaving the lots table stale.
- Now, if the refreshed account is tradable, `load-tradable-account` is called inside the async callback so lots and prices are reloaded with the fresh date range that covers the purchase date.

## Root cause of both symptoms
1. **Lots not updating** — `load-lots` was never called after a trade save.
2. **Gain/loss using previous price** — `load-prices` was never called after a trade save, so the new purchase-price record was missing from the prices list; gain/loss defaulted to the pre-purchase latest price instead of zero.

## Test plan
- [ ] Open a tradable account and click "+ Buy/Sell"
- [ ] Enter quantity, value, and submit
- [ ] Confirm the lots table updates immediately without navigating away
- [ ] Confirm gain/loss on the new lot shows 0 (purchase price = latest price)

🤖 Generated with [Claude Code](https://claude.com/claude-code)