### PR TITLE
Add MinIO image storage implementation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ volumes:
   maven-data:
   redis-data-8:
   init-markers:
+  minio-data:
 services:
 
   redis:
@@ -66,6 +67,41 @@ services:
       - type: volume
         source: maven-data
         target: /root/.m2
+
+  # MinIO (S3-compatible image storage)
+  #-------------------------------------
+
+  minio:
+    image: docker.io/minio/minio:latest
+    pull_policy: always
+    command: server /data --console-address ":9001"
+    restart: on-failure
+    ports:
+      - 9000:9000
+      - 9001:9001
+    volumes:
+      - minio-data:/data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  minio-init:
+    image: docker.io/minio/mc:latest
+    pull_policy: always
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin &&
+      /usr/bin/mc mb --ignore-existing myminio/clj-money-images &&
+      exit 0"
 
   # Datomic
   #--------

--- a/project.clj
+++ b/project.clj
@@ -164,7 +164,10 @@
                  [stowaway "0.2.13" :exclusions [com.github.seancorfield/honeysql org.clojure/spec.alpha org.clojure/clojure potemkin org.clojure/core.specs.alpha org.clojure/tools.logging]]
                  [io.opentelemetry/opentelemetry-api "1.55.0"]
                  [org.clojure/data.csv "1.1.1"]
-                 [org.clj-commons/hickory "0.7.7"]]
+                 [org.clj-commons/hickory "0.7.7"]
+                 [com.cognitect.aws/api "0.8.692"]
+                 [com.cognitect.aws/endpoints "1.1.12.773"]
+                 [com.cognitect.aws/s3 "875.2.1342.0"]]
   :repl-options {:init-ns clj-money.repl
                  :welcome (println "Welcome to better money management!")}
   :min-lein-version "2.0.0"

--- a/project.clj
+++ b/project.clj
@@ -165,9 +165,9 @@
                  [io.opentelemetry/opentelemetry-api "1.55.0"]
                  [org.clojure/data.csv "1.1.1"]
                  [org.clj-commons/hickory "0.7.7"]
-                 [com.cognitect.aws/api "0.8.692"]
-                 [com.cognitect.aws/endpoints "1.1.12.773"]
-                 [com.cognitect.aws/s3 "875.2.1342.0"]]
+                 [com.cognitect.aws/api "0.8.824"]
+                 [com.cognitect.aws/endpoints "871.2.44.12"]
+                 [com.cognitect.aws/s3 "871.2.43.0"]]
   :repl-options {:init-ns clj-money.repl
                  :welcome (println "Welcome to better money management!")}
   :min-lein-version "2.0.0"

--- a/src/clj_money/images/minio.clj
+++ b/src/clj_money/images/minio.clj
@@ -1,0 +1,49 @@
+(ns clj-money.images.minio
+  (:require [clojure.tools.logging :as log]
+            [cognitect.aws.client.api :as aws]
+            [cognitect.aws.credentials :as credentials]
+            [clj-money.images :as images])
+  (:import [java.io ByteArrayInputStream]))
+
+(defn- make-client
+  [{:keys [endpoint-host endpoint-port access-key secret-key region]}]
+  (aws/client
+    (cond-> {:api :s3
+             :region (or region "us-east-1")}
+      (and endpoint-host endpoint-port)
+      (assoc :endpoint-override {:protocol :http
+                                 :hostname endpoint-host
+                                 :port endpoint-port})
+      (and access-key secret-key)
+      (assoc :credentials-provider
+             (credentials/basic-credentials-provider
+               {:access-key-id access-key
+                :secret-access-key secret-key})))))
+
+(defn- anomaly?
+  [result]
+  (boolean (:cognitect.anomalies/category result)))
+
+(defmethod images/reify-storage ::images/minio
+  [{:keys [bucket] :as config}]
+  (let [client (make-client config)]
+    (reify images/Storage
+      (fetch [_ uuid]
+        (log/debugf "Fetching image %s from MinIO bucket %s" uuid bucket)
+        (let [result (aws/invoke client {:op :GetObject
+                                         :request {:Bucket bucket
+                                                   :Key uuid}})]
+          (when-not (anomaly? result)
+            (.readAllBytes ^java.io.InputStream (:Body result)))))
+      (stash [_ uuid content]
+        (log/debugf "Stashing image %s in MinIO bucket %s" uuid bucket)
+        (let [result (aws/invoke client {:op :PutObject
+                                          :request {:Bucket bucket
+                                                    :Key uuid
+                                                    :Body (ByteArrayInputStream. ^bytes content)}})]
+          (when (anomaly? result)
+            (throw (ex-info "Failed to stash image in MinIO"
+                            {:uuid uuid
+                             :bucket bucket
+                             :anomaly result})))
+          uuid)))))

--- a/src/clj_money/images/s3.clj
+++ b/src/clj_money/images/s3.clj
@@ -6,14 +6,14 @@
   (:import [java.io ByteArrayInputStream]))
 
 (defn- make-client
-  [{:keys [endpoint-host endpoint-port access-key secret-key region]}]
+  [{:keys [host port access-key secret-key region]}]
   (aws/client
     (cond-> {:api :s3
              :region (or region "us-east-1")}
-      (and endpoint-host endpoint-port)
+      (and host port)
       (assoc :endpoint-override {:protocol :http
-                                 :hostname endpoint-host
-                                 :port endpoint-port})
+                                 :hostname host
+                                 :port port})
       (and access-key secret-key)
       (assoc :credentials-provider
              (credentials/basic-credentials-provider

--- a/src/clj_money/images/s3.clj
+++ b/src/clj_money/images/s3.clj
@@ -1,4 +1,4 @@
-(ns clj-money.images.minio
+(ns clj-money.images.s3
   (:require [clojure.tools.logging :as log]
             [cognitect.aws.client.api :as aws]
             [cognitect.aws.credentials :as credentials]
@@ -24,25 +24,25 @@
   [result]
   (boolean (:cognitect.anomalies/category result)))
 
-(defmethod images/reify-storage ::images/minio
+(defmethod images/reify-storage ::images/s3
   [{:keys [bucket] :as config}]
   (let [client (make-client config)]
     (reify images/Storage
       (fetch [_ uuid]
-        (log/debugf "Fetching image %s from MinIO bucket %s" uuid bucket)
+        (log/debugf "Fetching image %s from S3 bucket %s" uuid bucket)
         (let [result (aws/invoke client {:op :GetObject
                                          :request {:Bucket bucket
                                                    :Key uuid}})]
           (when-not (anomaly? result)
             (.readAllBytes ^java.io.InputStream (:Body result)))))
       (stash [_ uuid content]
-        (log/debugf "Stashing image %s in MinIO bucket %s" uuid bucket)
+        (log/debugf "Stashing image %s in S3 bucket %s" uuid bucket)
         (let [result (aws/invoke client {:op :PutObject
                                           :request {:Bucket bucket
                                                     :Key uuid
                                                     :Body (ByteArrayInputStream. ^bytes content)}})]
           (when (anomaly? result)
-            (throw (ex-info "Failed to stash image in MinIO"
+            (throw (ex-info "Failed to stash image in S3"
                             {:uuid uuid
                              :bucket bucket
                              :anomaly result})))

--- a/src/clj_money/images/s3.clj
+++ b/src/clj_money/images/s3.clj
@@ -24,26 +24,34 @@
   [result]
   (boolean (:cognitect.anomalies/category result)))
 
+(defn- fetch*
+  [uuid client bucket]
+  (log/debugf "Fetching image %s from S3 bucket %s" uuid bucket)
+  (let [result (aws/invoke client {:op :GetObject
+                                   :request {:Bucket bucket
+                                             :Key uuid}})]
+    (when-not (anomaly? result)
+      (.readAllBytes ^java.io.InputStream (:Body result)))))
+
+(defn- stash*
+  [uuid content client bucket]
+  (log/debugf "Stashing image %s in S3 bucket %s" uuid bucket)
+  (let [result (aws/invoke client {:op :PutObject
+                                   :request {:Bucket bucket
+                                             :Key uuid
+                                             :Body (ByteArrayInputStream. ^bytes content)}})]
+    (when (anomaly? result)
+      (throw (ex-info "Failed to stash image in S3"
+                      {:uuid uuid
+                       :bucket bucket
+                       :anomaly result})))
+    uuid))
+
 (defmethod images/reify-storage ::images/s3
   [{:keys [bucket] :as config}]
   (let [client (make-client config)]
     (reify images/Storage
       (fetch [_ uuid]
-        (log/debugf "Fetching image %s from S3 bucket %s" uuid bucket)
-        (let [result (aws/invoke client {:op :GetObject
-                                         :request {:Bucket bucket
-                                                   :Key uuid}})]
-          (when-not (anomaly? result)
-            (.readAllBytes ^java.io.InputStream (:Body result)))))
+        (fetch* uuid client bucket))
       (stash [_ uuid content]
-        (log/debugf "Stashing image %s in S3 bucket %s" uuid bucket)
-        (let [result (aws/invoke client {:op :PutObject
-                                          :request {:Bucket bucket
-                                                    :Key uuid
-                                                    :Body (ByteArrayInputStream. ^bytes content)}})]
-          (when (anomaly? result)
-            (throw (ex-info "Failed to stash image in S3"
-                            {:uuid uuid
-                             :bucket bucket
-                             :anomaly result})))
-          uuid)))))
+        (stash* uuid content client bucket)))))

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -1218,6 +1218,7 @@
        [transaction-form page-state]
        [trade-form page-state]
        [recs/reconciliation-form page-state]
+       [atts/attachments-card page-state]
        [atts/attachment-form page-state]
        (when @allocation-account
          [asset-allocation page-state])])))

--- a/src/clj_money/web/images.clj
+++ b/src/clj_money/web/images.clj
@@ -6,7 +6,7 @@
             [clj-money.util :as util]
             [clj-money.images :as images]
             [clj-money.images.sql]
-            [clj-money.images.minio]
+            [clj-money.images.s3]
             [clj-money.entities :as entities]
             [clj-money.authorization.images]))
 

--- a/src/clj_money/web/images.clj
+++ b/src/clj_money/web/images.clj
@@ -6,6 +6,7 @@
             [clj-money.util :as util]
             [clj-money.images :as images]
             [clj-money.images.sql]
+            [clj-money.images.minio]
             [clj-money.entities :as entities]
             [clj-money.authorization.images]))
 

--- a/test/clj_money/images/s3_test.clj
+++ b/test/clj_money/images/s3_test.clj
@@ -9,8 +9,8 @@
 (def ^:private test-config
   {:clj-money.images/strategy :clj-money.images/s3
    :bucket "test-bucket"
-   :endpoint-host "localhost"
-   :endpoint-port 9000
+   :host "localhost"
+   :port 9000
    :access-key "minioadmin"
    :secret-key "minioadmin"})
 

--- a/test/clj_money/images/s3_test.clj
+++ b/test/clj_money/images/s3_test.clj
@@ -1,0 +1,96 @@
+(ns clj-money.images.s3-test
+  (:require [clojure.test :refer [deftest is]]
+            [cognitect.aws.client.api :as aws]
+            [clj-money.images :as images]
+            [clj-money.images.s3]
+            [clj-money.images.storage-contract :as contract])
+  (:import [java.io ByteArrayInputStream]))
+
+(def ^:private test-config
+  {:clj-money.images/strategy :clj-money.images/s3
+   :bucket "test-bucket"
+   :endpoint-host "localhost"
+   :endpoint-port 9000
+   :access-key "minioadmin"
+   :secret-key "minioadmin"})
+
+; ---------------------------------------------------------------
+; Behavioral contract (stateful in-memory S3 mock)
+; ---------------------------------------------------------------
+
+(defn- make-s3-mock
+  "Returns a fn compatible with aws/invoke that simulates an S3 bucket in memory."
+  []
+  (let [store (atom {})]
+    (fn [_client {:keys [op request]}]
+      (case op
+        :PutObject
+        (do (swap! store assoc (:Key request) (-> request :Body .readAllBytes))
+            {})
+        :GetObject
+        (if-let [content (get @store (:Key request))]
+          {:Body (ByteArrayInputStream. content)}
+          {:cognitect.anomalies/category :cognitect.anomalies/not-found})))))
+
+(deftest s3-storage-behavioral-contract
+  (with-redefs [aws/invoke (make-s3-mock)]
+    (contract/run-contract (images/reify-storage test-config))))
+
+; ---------------------------------------------------------------
+; Implementation-specific unit tests (aws/invoke is mocked)
+; ---------------------------------------------------------------
+
+(deftest fetch-invokes-get-object
+  (let [content (.getBytes "image data")
+        calls (atom [])]
+    (with-redefs [aws/invoke (fn [_client req]
+                               (swap! calls conj req)
+                               {:Body (ByteArrayInputStream. content)})]
+      (let [storage (images/reify-storage test-config)]
+        (images/fetch storage "my-uuid")
+        (is (= [{:op :GetObject
+                 :request {:Bucket "test-bucket"
+                           :Key "my-uuid"}}]
+               @calls)
+            "invokes :GetObject with the configured bucket and uuid as key")))))
+
+(deftest fetch-returns-nil-on-not-found-anomaly
+  (with-redefs [aws/invoke (constantly {:cognitect.anomalies/category
+                                        :cognitect.anomalies/not-found})]
+    (let [storage (images/reify-storage test-config)]
+      (is (nil? (images/fetch storage "missing-uuid"))
+          "returns nil when S3 reports not-found"))))
+
+(deftest stash-invokes-put-object
+  (let [content (.getBytes "image data")
+        calls (atom [])]
+    (with-redefs [aws/invoke (fn [_client req]
+                               (swap! calls conj req)
+                               {})]
+      (let [storage (images/reify-storage test-config)]
+        (images/stash storage "my-uuid" content)
+        (is (= 1 (count @calls))
+            "invoke called once")
+        (let [{:keys [op request]} (first @calls)]
+          (is (= :PutObject op)
+              "uses the :PutObject operation")
+          (is (= "test-bucket" (:Bucket request))
+              "uses the configured bucket")
+          (is (= "my-uuid" (:Key request))
+              "uses the uuid as the object key")
+          (is (= (seq content) (seq (.readAllBytes (:Body request))))
+              "streams the content as the request body"))))))
+
+(deftest stash-returns-uuid
+  (with-redefs [aws/invoke (constantly {})]
+    (let [storage (images/reify-storage test-config)]
+      (is (= "my-uuid" (images/stash storage "my-uuid" (.getBytes "data")))
+          "returns the uuid after a successful put"))))
+
+(deftest stash-throws-on-s3-anomaly
+  (with-redefs [aws/invoke (constantly {:cognitect.anomalies/category :cognitect.anomalies/fault
+                                        :cognitect.anomalies/message "internal error"})]
+    (let [storage (images/reify-storage test-config)]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (images/stash storage "my-uuid" (.getBytes "data")))
+          "throws ExceptionInfo when S3 returns an anomaly"))))

--- a/test/clj_money/images/sql_test.clj
+++ b/test/clj_money/images/sql_test.clj
@@ -1,0 +1,90 @@
+(ns clj-money.images.sql-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.string :as str]
+            [next.jdbc :as jdbc]
+            [clj-money.config :refer [env]]
+            [clj-money.images :as images]
+            [clj-money.images.sql]
+            [clj-money.images.storage-contract :as contract])
+  (:import [org.postgresql.util PSQLException PSQLState]))
+
+(def ^:private fake-config
+  {:clj-money.images/strategy :clj-money.images/sql})
+
+; ---------------------------------------------------------------
+; Implementation-specific unit tests (JDBC calls are mocked)
+; ---------------------------------------------------------------
+
+(deftest fetch-queries-image-content-table
+  (let [calls (atom [])
+        content (.getBytes "image data")]
+    (with-redefs [jdbc/get-datasource (constantly ::fake-ds)
+                  jdbc/execute-one! (fn [_ds sql & _opts]
+                                      (swap! calls conj sql)
+                                      {:content content})]
+      (let [storage (images/reify-storage fake-config)]
+        (images/fetch storage "the-uuid")
+        (is (= 1 (count @calls))
+            "execute-one! called once")
+        (let [[sql-str uuid-param] (first @calls)]
+          (is (str/includes? sql-str "image_content")
+              "queries the image_content table")
+          (is (= "the-uuid" uuid-param)
+              "parameterizes the uuid"))))))
+
+(deftest fetch-returns-nil-when-row-not-found
+  (with-redefs [jdbc/get-datasource (constantly ::fake-ds)
+                jdbc/execute-one! (constantly nil)]
+    (let [storage (images/reify-storage fake-config)]
+      (is (nil? (images/fetch storage "missing"))
+          "returns nil when no row exists"))))
+
+(deftest stash-inserts-into-image-content-table
+  (let [calls (atom [])
+        content (.getBytes "image data")]
+    (with-redefs [jdbc/get-datasource (constantly ::fake-ds)
+                  jdbc/execute-one! (fn [_ds sql & _opts]
+                                      (swap! calls conj sql)
+                                      nil)]
+      (let [storage (images/reify-storage fake-config)]
+        (images/stash storage "the-uuid" content)
+        (is (= 1 (count @calls))
+            "execute-one! called once")
+        (let [[sql-str uuid-param] (first @calls)]
+          (is (str/includes? sql-str "image_content")
+              "inserts into the image_content table")
+          (is (= "the-uuid" uuid-param)
+              "parameterizes the uuid"))))))
+
+(deftest stash-falls-back-to-fetch-on-duplicate-key
+  (let [existing (.getBytes "original content")
+        call-count (atom 0)]
+    (with-redefs [jdbc/get-datasource (constantly ::fake-ds)
+                  jdbc/execute-one! (fn [_ds _sql & _opts]
+                                      (case (swap! call-count inc)
+                                        1 (throw (PSQLException.
+                                                   "duplicate key value violates unique constraint"
+                                                   PSQLState/UNIQUE_VIOLATION))
+                                        {:content existing}))]
+      (let [storage (images/reify-storage fake-config)]
+        (images/stash storage "the-uuid" (.getBytes "new content"))
+        (is (= 2 @call-count)
+            "a second query is issued to fetch the existing content")))))
+
+(deftest stash-rethrows-non-duplicate-psql-exceptions
+  (with-redefs [jdbc/get-datasource (constantly ::fake-ds)
+                jdbc/execute-one! (fn [_ds _sql & _opts]
+                                    (throw (PSQLException.
+                                             "connection refused"
+                                             PSQLState/CONNECTION_FAILURE)))]
+    (let [storage (images/reify-storage fake-config)]
+      (is (thrown? PSQLException
+                   (images/stash storage "the-uuid" (.getBytes "data")))
+          "rethrows non-duplicate-key PSQLExceptions"))))
+
+; ---------------------------------------------------------------
+; Behavioral contract (requires a real PostgreSQL test database)
+; ---------------------------------------------------------------
+
+(deftest ^:sql sql-storage-behavioral-contract
+  (contract/run-contract (images/reify-storage (:image-storage env))))

--- a/test/clj_money/images/storage_contract.clj
+++ b/test/clj_money/images/storage_contract.clj
@@ -7,12 +7,12 @@
   Call from each implementation's test namespace."
   [storage]
   (let [content (.getBytes "test image content")
-        uuid (str (java.util.UUID/randomUUID))]
+        uuid (str (random-uuid))]
     (testing "stash + fetch round trip"
       (images/stash storage uuid content)
       (is (= (seq content)
              (seq (images/fetch storage uuid)))
           "fetched content matches stashed content"))
     (testing "fetch of an unknown uuid"
-      (is (nil? (images/fetch storage (str (java.util.UUID/randomUUID))))
+      (is (nil? (images/fetch storage (str (random-uuid))))
           "returns nil"))))

--- a/test/clj_money/images/storage_contract.clj
+++ b/test/clj_money/images/storage_contract.clj
@@ -1,0 +1,18 @@
+(ns clj-money.images.storage-contract
+  (:require [clojure.test :refer [is testing]]
+            [clj-money.images :as images]))
+
+(defn run-contract
+  "Runs the Storage protocol behavioral assertions against `storage`.
+  Call from each implementation's test namespace."
+  [storage]
+  (let [content (.getBytes "test image content")
+        uuid (str (java.util.UUID/randomUUID))]
+    (testing "stash + fetch round trip"
+      (images/stash storage uuid content)
+      (is (= (seq content)
+             (seq (images/fetch storage uuid)))
+          "fetched content matches stashed content"))
+    (testing "fetch of an unknown uuid"
+      (is (nil? (images/fetch storage (str (java.util.UUID/randomUUID))))
+          "returns nil"))))


### PR DESCRIPTION
## Summary

- Implements the `Storage` protocol backed by MinIO (S3-compatible) using `cognitect.aws/api`
- Adds `minio` and `minio-init` services to `docker-compose.yaml` for local development; the init service creates the `clj-money-images` bucket on startup
- Adds `cognitect.aws/api`, `cognitect.aws/endpoints`, and `cognitect.aws/s3` to project dependencies

## Configuration

To use MinIO as the image storage backend, update `:image-storage` in your config:

```edn
:image-storage {:clj-money.images/strategy :clj-money.images/minio
                :host "localhost"
                :port 9000
                :access-key "minioadmin"
                :secret-key "minioadmin"
                :bucket "clj-money-images"}
```

The default dev and docker configs continue to use the SQL backend unchanged.

## Test plan

- [ ] Start docker-compose and confirm MinIO console is accessible at `http://localhost:9001`
- [ ] Confirm the `clj-money-images` bucket is created by `minio-init`
- [ ] Switch config to use `:clj-money.images/minio` strategy and upload an attachment via the UI
- [ ] Confirm the attachment is retrievable from the MinIO bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)