### PR TITLE
Add HoneyBadger error monitoring

### DIFF
--- a/env/test/config.edn
+++ b/env/test/config.edn
@@ -46,6 +46,7 @@
  :github-client-secret "github-client-secret"
  :google-client-id "google-id"
  :google-client-secret "google-client-secret"
+ :honeybadger-api-key nil
  :oauth-providers #{:google :github}
  :redis-host "localhost"
  :redis-password "please04"

--- a/src/clj_money/honeybadger.clj
+++ b/src/clj_money/honeybadger.clj
@@ -1,0 +1,36 @@
+(ns clj-money.honeybadger
+  (:require [clojure.tools.logging :as log]
+            [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clj-money.config :refer [env]]))
+
+(defn- format-frame
+  [^StackTraceElement frame]
+  {:number (str (.getLineNumber frame))
+   :file (or (.getFileName frame) "unknown")
+   :method (format "%s.%s" (.getClassName frame) (.getMethodName frame))})
+
+(defn- exception->payload
+  [^Throwable e]
+  {:notifier {:name "clj-money"
+              :version "1.0.0"
+              :url "https://github.com/dgknght/clj-money"}
+   :error {:class (.getName (.getClass e))
+           :message (or (ex-message e) "")
+           :backtrace (mapv format-frame (.getStackTrace e))}
+   :server {:environment_name (if (env :dev?) "development" "production")
+            :hostname (.. java.net.InetAddress getLocalHost getHostName)}})
+
+(defn notify
+  [^Throwable e]
+  (when-let [api-key (env :honeybadger-api-key)]
+    (future
+      (try
+        (http/post "https://api.honeybadger.io/v1/notices"
+                   {:headers {"X-API-Key" api-key
+                              "Content-Type" "application/json"
+                              "Accept" "application/json"}
+                    :body (json/generate-string (exception->payload e))
+                    :throw-exceptions false})
+        (catch Exception err
+          (log/error err "Failed to notify HoneyBadger"))))))

--- a/src/clj_money/honeybadger.clj
+++ b/src/clj_money/honeybadger.clj
@@ -24,13 +24,12 @@
 (defn notify
   [^Throwable e]
   (when-let [api-key (env :honeybadger-api-key)]
-    (future
-      (try
-        (http/post "https://api.honeybadger.io/v1/notices"
-                   {:headers {"X-API-Key" api-key
-                              "Content-Type" "application/json"
-                              "Accept" "application/json"}
-                    :body (json/generate-string (exception->payload e))
-                    :throw-exceptions false})
-        (catch Exception err
-          (log/error err "Failed to notify HoneyBadger"))))))
+    (try
+      (http/post "https://api.honeybadger.io/v1/notices"
+                 {:headers {"X-API-Key" api-key
+                            "Content-Type" "application/json"
+                            "Accept" "application/json"}
+                  :body (json/generate-string (exception->payload e))
+                  :throw-exceptions false})
+      (catch Exception err
+        (log/error err "Failed to notify HoneyBadger")))))

--- a/src/clj_money/middleware.clj
+++ b/src/clj_money/middleware.clj
@@ -17,7 +17,8 @@
             [clj-money.formats :as fmts]
             [clj-money.authorization :as authorization]
             [clj-money.entities :as entities]
-            [clj-money.api :refer [log-error]])
+            [clj-money.api :refer [log-error]]
+            [clj-money.honeybadger :as honeybadger])
   (:import com.fasterxml.jackson.core.JsonGenerator))
 
 (defn- param-name
@@ -105,6 +106,7 @@
   (if-let [details (ex-data e)]
     (log/errorf e "Unexpected ExceptionInfo was encountered while handling the web request: %s" (pr-str details))
     (log/error e "Unexpected ExceptionInfo was encountered while handling the web request."))
+  (honeybadger/notify e)
   api/internal-server-error)
 
 ; TODO: Move this to the api namespace
@@ -118,6 +120,7 @@
        (handle-exception e))
      (catch Exception e
        (log-error e "unexpected error")
+       (honeybadger/notify e)
        (-> {:message (str "unexpected error: " (ex-message e))}
            response
            (status 500))))))

--- a/test/clj_money/honeybadger_test.clj
+++ b/test/clj_money/honeybadger_test.clj
@@ -1,0 +1,34 @@
+(ns clj-money.honeybadger-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clj-http.client :as http]
+            [clj-money.config :as config]
+            [clj-money.honeybadger :as honeybadger]))
+
+(def ^:private test-error
+  (Exception. "something went wrong"))
+
+(deftest notify-sends-to-honeybadger-when-key-is-configured
+  (testing "when the api key is configured"
+    (let [calls (atom [])]
+      (with-redefs [http/post (fn [url opts] (swap! calls conj {:url url :opts opts}))
+                    config/env (fn [k]
+                                 (when (= :honeybadger-api-key k)
+                                   "test-api-key"))]
+        (let [f (honeybadger/notify test-error)]
+          (when f @f))
+        (is (= 1 (count @calls))
+            "One POST request is made")
+        (let [{:keys [url opts]} (first @calls)]
+          (is (= "https://api.honeybadger.io/v1/notices" url)
+              "Posts to the HoneyBadger notices endpoint")
+          (is (= "test-api-key" (get-in opts [:headers "X-API-Key"]))
+              "Sends the API key header"))))))
+
+(deftest notify-is-noop-without-api-key
+  (testing "when the api key is not configured"
+    (let [calls (atom [])]
+      (with-redefs [http/post (fn [url opts] (swap! calls conj {:url url :opts opts}))
+                    config/env (constantly nil)]
+        (honeybadger/notify test-error)
+        (is (empty? @calls)
+            "No HTTP calls are made")))))

--- a/test/clj_money/honeybadger_test.clj
+++ b/test/clj_money/honeybadger_test.clj
@@ -14,8 +14,7 @@
                     config/env (fn [k]
                                  (when (= :honeybadger-api-key k)
                                    "test-api-key"))]
-        (let [f (honeybadger/notify test-error)]
-          (when f @f))
+        (honeybadger/notify test-error)
         (is (= 1 (count @calls))
             "One POST request is made")
         (let [{:keys [url opts]} (first @calls)]


### PR DESCRIPTION
## Summary

- Adds `clj-money.honeybadger/notify` which posts exception details to the HoneyBadger v1 API using `clj-http` (already a dependency)
- Wires `notify` into `wrap-exceptions` for both unexpected `ExceptionInfo` (`:default` handler) and plain `Exception` catches
- Integration is a no-op when `:honeybadger-api-key` is not configured, so dev/test environments are unaffected
- Adds `:honeybadger-api-key nil` placeholder to the test config

## Test plan

- [ ] Run `lein test clj-money.honeybadger-test` — 2 tests, 4 assertions
- [ ] Run `lein test clj-money.middleware-test` — no regressions
- [ ] Set `HONEYBADGER_API_KEY` in a staging environment and trigger a 500 error to verify the notice appears in HoneyBadger

🤖 Generated with [Claude Code](https://claude.com/claude-code)