### PR TITLE
Fix reconciliation status filter crashing Datomic

### DIFF
--- a/src/clj_money/api/reconciliations.clj
+++ b/src/clj_money/api/reconciliations.clj
@@ -36,6 +36,7 @@
       (select-keys [:reconciliation/account
                     :reconciliation/status
                     :reconciliation/end-of-period])
+      (update-in-if [:reconciliation/status] util/ensure-keyword)
       (+scope :reconciliation authenticated)))
 
 (defn- translate-sort

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -271,6 +271,33 @@
   (with-context update-context
     (assert-blocked-update (update-reconciliation "jane@doe.com"))))
 
+(defn- get-reconciliations-by-status
+  [email status]
+  (let [account (find-account "Checking")]
+    (-> (request :get (str (path :api
+                                 :accounts
+                                 (:id account)
+                                 :reconciliations)
+                           "?reconciliation_status=" (name status))
+                 :user (find-user email))
+        app
+        parse-body)))
+
+(deftest a-user-can-filter-reconciliations-by-status
+  (with-context update-context
+    (testing "filtering by :new status returns only in-progress reconciliations"
+      (let [{:as response :keys [parsed-body]} (get-reconciliations-by-status "john@doe.com" :new)]
+        (is (http-success? response))
+        (is (seq-of-maps-like? [#:reconciliation{:end-of-period (t/local-date 2015 2 4)}]
+                               parsed-body)
+            "Only the :new reconciliation is returned")))
+    (testing "filtering by :completed status returns only completed reconciliations"
+      (let [{:as response :keys [parsed-body]} (get-reconciliations-by-status "john@doe.com" :completed)]
+        (is (http-success? response))
+        (is (seq-of-maps-like? [#:reconciliation{:end-of-period (t/local-date 2015 1 4)}]
+                               parsed-body)
+            "Only the :completed reconciliation is returned")))))
+
 (deftest ^:multi-threaded a-database-error-produces-a-parseable-500-response
   (with-context recon-context
     (with-redefs [entities/select (fn [& _]


### PR DESCRIPTION
## Summary

- `extract-criteria` in `api/reconciliations.clj` was passing `:reconciliation/status` as a raw string (e.g. `"new"`) to Datomic, which expects a keyword
- The ClojureScript client calls `(name status)` before encoding the query param, so the server always receives a string
- `extract-recon` (the create/update path) already called `util/ensure-keyword` on the status — this fix applies the same coercion to `extract-criteria` (the index/query path)

## Test plan

- [ ] New test `a-user-can-filter-reconciliations-by-status` verifies both `:new` and `:completed` filters return the correct subset of reconciliations
- [ ] All 13 existing reconciliation API tests still pass
- [ ] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)