### PR TITLE
Add Renovate for automated dependency updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,14 +27,9 @@ We own two of the libraries used throughout this projects.
 - `dgknght.app-lib` - Source at `../app-lib`
 - `stowaway` - Source at `../stowaway`
 
-## See also
+## Guidelines
 
-- [Architecture](.claude/architecture.md) — project layout, entity pattern,
-  auth flow
-- [New Entity Checklist](.claude/new-entity.md) — all steps to add a new
-  entity type
-- [stowaway](.claude/stowaway.md) — storage abstraction library (local dep)
-- [app-lib](.claude/app-lib.md) — utility library (local dep)
-- [Code Style](.claude/instructions.md) — naming, conventions, REPL workflow
-- [Patterns](.claude/patterns.md) — cross-backend query patterns, solved
-  problems
+- After making changes:
+  - Review the documentation and ensure that it is up-to-date.
+  - Run unit tests with code coverage to ensure all tests pass
+    and coverage has not slipped below the configured minimum.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,13 +7,7 @@
 
 ## Setup
 
-1. Run the system setup task (requires sudo for the PostgreSQL client install):
-
-   ```bash
-   mise run deps-system
-   ```
-
-2. Create `env/dev/config.edn` and `env/docker/config.edn` by copying `env/test/config.edn` and adjusting:
+1. Create `env/dev/config.edn` and `env/docker/config.edn` by copying `env/test/config.edn` and adjusting:
    - The database details (change `:dbname` to the dev database name)
    - The image storage details (change `:dbname` to the dev database name)
    - OAuth keys: `:google-client-id` and `:google-client-secret`
@@ -22,7 +16,7 @@
 
    To suppress outgoing email during local development, omit `:mailer-enabled?` or set it to `false`.
 
-3. Add a `env/docker/transactor.properties` file
+2. Add a `env/docker/transactor.properties` file
 
   ```bash
   host=0.0.0.0
@@ -45,18 +39,19 @@
   memcached=memcached:11211
   ```
 
-4. Run the full setup task:
+3. Run the full setup task:
 
    ```bash
    mise run setup
    ```
 
-   The `setup` task:
+   You will be prompted for your sudo password to install the PostgreSQL client. After that, the following run in parallel:
    - Starts Podman containers (datomic-peer profile: PostgreSQL, Redis, Memcached, Datomic transactor)
    - Installs Clojure and JS dependencies
    - Installs the sass CLI and does an initial compile
    - Downloads the OpenTelemetry Java agent
    - Initializes clj-kondo configs for all dependencies
+   - Configures git to use the repo's pre-push hook (runs the linter before each push)
 
    Datomic schema initialization runs automatically inside the Docker stack.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,16 @@ Stop the client:
 :cljs/quit
 ```
 
+## Dependency Updates
+
+Dependencies are kept current via [Renovate](https://github.com/apps/renovate). It is configured in `renovate.json` to open weekly PRs (Monday mornings, America/Chicago) covering:
+
+- Clojure dependencies (`project.clj`) — grouped into a single PR
+- Tool versions (`mise.toml`) — grouped into a single PR
+- Docker image versions (`docker-compose.yaml`) — one PR per image
+
+To activate Renovate on a new fork or installation, install the [Renovate GitHub App](https://github.com/apps/renovate) and grant it access to this repository.
+
 ## OpenTelemetry
 
 The OTEL Java agent is downloaded by `mise run setup`. To use it:

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+echo "Running linter..."
+clj-kondo --lint src:test

--- a/mise.toml
+++ b/mise.toml
@@ -11,9 +11,9 @@ clj-kondo = "2026.01.19"
 description = "Lint Clojure source"
 run = "clj-kondo --lint src:test"
 
-[tasks.setup]
-description = "Full first-time project setup (datomic strategy)"
-depends = ["docker-up", "lein-deps", "npm-install", "deps-system", "sass", "lint-deps", "download-otel"]
+[tasks.install-hooks]
+description = "Configure git to use the repo's hooks/ directory"
+run = "git config core.hooksPath hooks"
 
 [tasks.lint-deps]
 description = "Initialize clj-kondo configs for all dependencies"
@@ -23,6 +23,15 @@ run = """clj-kondo --lint "$(lein classpath)" --dependencies --parallel --copy-c
 [tasks.deps-system]
 description = "Install system dependencies (requires sudo)"
 run = "sudo dnf install -y postgresql"
+
+[tasks.setup-parallel]
+description = "Non-interactive setup tasks (run in parallel after deps-system)"
+depends = ["docker-up", "lein-deps", "npm-install", "sass", "lint-deps", "download-otel", "install-hooks"]
+
+[tasks.setup]
+description = "Full first-time project setup (datomic strategy)"
+depends = ["deps-system"]
+run = "mise run setup-parallel"
 
 [tasks.docker-up]
 description = "Start Docker containers (datomic-peer profile)"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "America/Chicago",
+  "schedule": ["before 9am on Monday"],
+  "packageRules": [
+    {
+      "description": "Group Clojure dependency updates into a single PR",
+      "matchManagers": ["leiningen"],
+      "groupName": "Clojure dependencies"
+    },
+    {
+      "description": "Group mise tool version updates",
+      "matchManagers": ["mise"],
+      "groupName": "mise tools"
+    },
+    {
+      "description": "Ignore custom internal Docker images",
+      "matchPackageNames": ["dgknght/datomic-pro"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `renovate.json` configuring Renovate to open weekly PRs (Monday mornings, America/Chicago)
- Groups Clojure dependencies (`project.clj`) into a single PR
- Groups mise tool versions (`mise.toml`) into a single PR
- Tracks Docker image versions (`docker-compose.yaml`) individually
- Excludes the internal `dgknght/datomic-pro` image from updates
- Documents Renovate setup in `docs/development.md`

## Test plan

- [ ] Install the [Renovate GitHub App](https://github.com/apps/renovate) and grant access to this repo to activate automated PRs
- [ ] Verify Renovate opens a dependency dashboard issue on first run
- [ ] Confirm PRs are created for outdated dependencies on the configured schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)