### PR TITLE
Only show OAuth links for configured providers

### DIFF
--- a/src/clj_money/web/apps.clj
+++ b/src/clj_money/web/apps.clj
@@ -4,13 +4,19 @@
             [clj-money.config :refer [env]]
             [clj-money.util :as util]
             [clj-money.entities :as entities]
+            [clj-money.web.auth.google :as google-auth]
+            [clj-money.web.auth.github :as github-auth]
             [hiccup.page :refer [html5 include-js]]))
-
-(def ^:private client-config-keys
-  #{:oauth-providers})
 
 (defn- needs-setup? []
   (zero? (entities/count (util/entity-type {} :user))))
+
+(defn- configured-oauth-providers
+  []
+  (let [providers (set (env :oauth-providers))]
+    (keys (not-empty
+            (merge (when (:google providers) (google-auth/oauth2-profile))
+                   (when (:github providers) (github-auth/oauth2-profile)))))))
 
 (defn- head [extra-config]
   [:head
@@ -24,7 +30,7 @@
    [:link  {:rel "icon" :href "images/logo.svg"}]
    [:title (env :application-name "clj-money?")]
    [:script {:type "application/edn" :id "app-config"}
-    (pr-str (merge (select-keys env client-config-keys) extra-config))]
+    (pr-str extra-config)]
 
    (include-js "https://unpkg.com/@popperjs/core@2")
    (include-js "js/bootstrap.min.js")
@@ -36,7 +42,8 @@
   {:status 200
    :body (html5
            [:html.h-100 {:lang "en"}
-            (head {:needs-setup? (needs-setup?)})
+            (head {:needs-setup? (needs-setup?)
+                   :oauth-providers (configured-oauth-providers)})
             [:body.h-100
              [:div#app.h-100
               [:nav.navbar.navbar-expand-lg.bg-body-tertiary

--- a/src/clj_money/web/apps.clj
+++ b/src/clj_money/web/apps.clj
@@ -11,12 +11,12 @@
 (defn- needs-setup? []
   (zero? (entities/count (util/entity-type {} :user))))
 
-(defn- configured-oauth-providers
-  []
-  (let [providers (set (env :oauth-providers))]
-    (keys (not-empty
-            (merge (when (:google providers) (google-auth/oauth2-profile))
-                   (when (:github providers) (github-auth/oauth2-profile)))))))
+(defn- oauth-providers []
+  (->> {:google (google-auth/oauth2-profile)
+        :github (github-auth/oauth2-profile)}
+       (filter second)
+       (map first)
+       set))
 
 (defn- head [extra-config]
   [:head
@@ -42,8 +42,8 @@
   {:status 200
    :body (html5
            [:html.h-100 {:lang "en"}
-            (head {:needs-setup? (needs-setup?)
-                   :oauth-providers (configured-oauth-providers)})
+            (head (merge {:needs-setup? (needs-setup?)
+                          :oauth-providers (oauth-providers)}))
             [:body.h-100
              [:div#app.h-100
               [:nav.navbar.navbar-expand-lg.bg-body-tertiary

--- a/src/clj_money/web/apps.clj
+++ b/src/clj_money/web/apps.clj
@@ -11,9 +11,18 @@
 (defn- needs-setup? []
   (zero? (entities/count (util/entity-type {} :user))))
 
+(def ^:private all-oauth-providers
+  {:google (google-auth/oauth2-profile)
+   :github (github-auth/oauth2-profile)})
+
+(def ^:private allow-listed-oauth-providers
+  (if-let [providers (env :oauth-providerrs)]
+    (select-keys all-oauth-providers
+                 providers)
+    all-oauth-providers))
+
 (defn- oauth-providers []
-  (->> {:google (google-auth/oauth2-profile)
-        :github (github-auth/oauth2-profile)}
+  (->> allow-listed-oauth-providers
        (filter second)
        (map first)
        set))


### PR DESCRIPTION
## Summary

- Filters `:oauth-providers` to only those with valid credentials before embedding in the client config
- Login and welcome pages no longer render sign-in buttons for providers whose client ID/secret are absent from the environment
- Uses the same `oauth2-profile` check that the server-side OAuth2 middleware already uses, avoiding duplication of credential logic

## Test plan

- [ ] With only one provider configured (e.g. GitHub), confirm only that button appears on the login page
- [ ] With neither provider configured, confirm the "Other sign in options" section is hidden entirely
- [ ] With both configured, confirm both buttons appear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)