### PR TITLE
Upgrade ring 1.10.0 → 1.15.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,9 @@
                                                                commons-codec
                                                                com.cognitect/transit-clj
                                                                org.eclipse.jetty/jetty-http
-                                                               org.eclipse.jetty/jetty-io]]
+                                                               org.eclipse.jetty/jetty-io
+                                                               org.eclipse.jetty/jetty-util
+                                                               org.eclipse.jetty/jetty-client]]
                  [crypto-random "1.2.1" :exclusions [commons-codec]] ; added to clarify dependencies
                  [buddy/buddy-sign "3.6.1-359" :exclusions [com.fasterxml.jackson.dataformat/jackson-dataformat-smile
                                                         com.fasterxml.jackson.dataformat/jackson-dataformat-cbor

--- a/project.clj
+++ b/project.clj
@@ -41,9 +41,9 @@
                  [org.threeten/threeten-extra "1.9.0"]
                  [clojure.java-time "1.4.3"]
                  [org.apache.commons/commons-fileupload2-javax "2.0.0-M5" :exclusions [commons-io]]
-                 [ring "1.10.0" :exclusions [commons-codec
+                 [ring "1.15.4" :exclusions [commons-codec
                                             commons-io]]
-                 [ring/ring-defaults "0.4.0" :exclusions [commons-fileupload
+                 [ring/ring-defaults "0.7.0" :exclusions [commons-fileupload
                                                           ring/ring-core]]
                  [metosin/reitit "0.10.1" :exclusions [com.cognitect/transit-java
                                                       org.clojure/spec.alpha

--- a/renovate.json
+++ b/renovate.json
@@ -21,12 +21,6 @@
       "description": "Ignore custom internal Docker images",
       "matchPackageNames": ["dgknght/datomic-pro"],
       "enabled": false
-    },
-    {
-      "description": "Pin ring until Jetty 12 / jakarta.servlet conflict with cognitect http-client is resolved",
-      "matchManagers": ["leiningen"],
-      "matchPackageNames": ["ring", "ring/ring-defaults", "ring/ring-core"],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Upgrades `ring` 1.10.0 → 1.15.4, `ring/ring-defaults` 0.4.0 → 0.7.0, managed `ring/ring-core` 1.12.2 → 1.15.4
- Removes the Renovate pin that was added in #167 to block the ring bump

This PR is a companion to #167 (the Renovate batch upgrade). Ring was deliberately held back there because of an unresolved build-breaking dependency conflict described below.

## Blocker: Jetty 12 vs cognitect http-client

`ring 1.15.4` → `ring-jetty-adapter 1.15.4` → `jetty-server 12.1.8` → `jetty-util 12.1.8`

`com.cognitect.aws/api` → `com.cognitect/http-client 1.0.127` → `jetty-util 9.4.53`

Maven's **nearest-wins** rule selects `jetty-util 9.4.53` (depth 3) over `jetty-util 12.1.8` (depth 5). Jetty 9.4.x does not have `org.eclipse.jetty.util.thread.AutoLock` (introduced in Jetty 10+), causing a `ClassNotFoundException` when AOT-compiling `ring.adapter.jetty`.

**Forcing Jetty 12 is not an option**: `cognitect/http-client 1.0.127` (latest available) directly uses Jetty 9 APIs that were removed in Jetty 12:
- `org.eclipse.jetty.client.api.*` — entire package removed (moved to `org.eclipse.jetty.client.*`)
- `org.eclipse.jetty.client.util.ByteBufferContentProvider` — removed
- `org.eclipse.jetty.util.log.Log` — removed (Jetty went SLF4J-only)

There is no newer version of `com.cognitect/http-client` that supports Jetty 12.

## What needs to happen before this can merge

Replace the Jetty-based HTTP transport used by `cognitect.aws` with one that is Jetty-agnostic. Options to investigate:

1. **Java 11 HttpClient adapter** — write a small `cognitect.aws.http` implementation backed by `java.net.http.HttpClient` (no Jetty dependency at all)
2. **Apache HttpClient 5 adapter** — similar, already used by clj-http
3. **Community library** — check if a maintained Jetty-free adapter already exists (e.g., `com.cognitect.aws/http-client-java11`)

Once the cognitect HTTP transport is swapped, ring 1.15.4 should build cleanly.

## Test plan

- [ ] Implement a replacement HTTP client for `cognitect.aws`
- [ ] `lein deps` resolves without Jetty conflicts
- [ ] `lein fig:test` compiles and passes
- [ ] `lein cloverage` passes with coverage thresholds met
- [ ] Spot-check S3 / AWS calls in a dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)