### PR TITLE
Fix: hide attachment list while editing a caption

### DIFF
--- a/src/clj_money/views/attachments.cljs
+++ b/src/clj_money/views/attachments.cljs
@@ -80,9 +80,10 @@
 
 (defn attachments-card
   [page-state]
-  (let [item (r/cursor page-state [:attachments-item])]
+  (let [item (r/cursor page-state [:attachments-item])
+        selected (r/cursor page-state [:selected-attachment])]
     (fn []
-      (when @item
+      (when (and @item (not @selected))
         [:div.card
          [:div.card-header
           [:strong "Attachments"]


### PR DESCRIPTION
## Summary

- When the user clicks the edit (pencil) button on an attachment, the `attachments-card` (which shows the attachment table/details) remained visible alongside the `attachment-form`.
- Fixed by adding a `:selected-attachment` cursor to `attachments-card` and gating its render on `(and @item (not @selected))` — so only the edit form is visible when editing.

## Test plan

- [ ] Navigate to an account with attachments on a transaction.
- [ ] Click the edit (pencil) icon on an attachment.
- [ ] Confirm only the edit form is visible (attachment details list is hidden).
- [ ] Save or cancel — confirm the attachment list reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)