### PR TITLE
Fix flaky async propagation tests

### DIFF
--- a/src/clj_money/entities.clj
+++ b/src/clj_money/entities.clj
@@ -234,8 +234,11 @@
     (when ctrl-chan
       (a/offer! ctrl-chan :start))
     (a/go
+      ; Use the parking <! here, not <!!, since we're inside a go block;
+      ; a blocking call here can starve the core.async dispatch pool
+      ; under load, delaying :finish and racing with-propagation's timeout.
       (when-let [changes (seq (calc-changes to-save saved))]
-        (a/<!! (a/onto-chan! out-chan changes close-chan?)))
+        (a/<! (a/onto-chan! out-chan changes close-chan?)))
       (when ctrl-chan
         (a/>! ctrl-chan :finish)))))
 
@@ -295,9 +298,10 @@
        (when ctrl-chan
          (a/offer! ctrl-chan :start))
        (a/go
-         (->> entities
-              (map #(vector % nil))
-              (a/onto-chan!! out-chan))
+         ; Parking <!, not blocking onto-chan!!/<!!, to avoid starving
+         ; the core.async dispatch pool (see emit-changes above).
+         (a/<! (a/onto-chan! out-chan
+                             (map #(vector % nil) entities)))
          (when ctrl-chan
            (a/>! ctrl-chan :finish))))
      result)))


### PR DESCRIPTION
## Summary
- `entities/emit-changes` and `entities/delete-many` used blocking channel operations (`<!!`, `onto-chan!!`) inside `a/go` blocks. Under load this can starve core.async's fixed-size dispatch thread pool, delaying the `:finish` signal that `with-propagation` waits on.
- When that delay exceeds the 5-second guard in `with-propagation` (`entities/propagation.clj`), the propagation result is returned before account balances have actually been recalculated, producing stale values — matching the `undo-a-purchase` flakiness reported on the Trello card ("Flaky tests").
- Switched both spots to the parking `<!` so the go blocks stay cooperative, letting `with-propagation` reliably wait for propagation to finish.

## Test plan
- [x] `lein test :only clj-money.trading-test/undo-a-purchase` x15 — all pass
- [x] `lein test :only clj-money.trading-test/undo-a-sale` x8 — all pass
- [x] `lein test :only clj-money.trading-test` — 29 tests, 0 failures
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [x] Full `lein test` run — pre-existing, unrelated failures confirmed present with and without this change (SQL connection errors from the local Postgres container, and an unrelated `QualifiedID` protocol gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)