### PR TITLE
Serialize the tag job 

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -71,6 +71,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions: write-all
+    concurrency:
+      group: tag-creation
+      cancel-in-progress: false
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7.0.0


### PR DESCRIPTION
...to prevent duplicate-tag races on concurrent merges

Three Renovate PRs merged to main within seconds of each other and each tag job computed the same next version before seeing the tag its sibling run had just pushed, causing a "Resource not accessible by integration" error on the losing run. Adding a concurrency group makes overlapping tag jobs queue instead of race, so each sees the previous job's tag.