### PR TITLE
Fix: reconciliation update fails when resubmitting items

### DIFF
--- a/src/clj_money/api/reconciliations.clj
+++ b/src/clj_money/api/reconciliations.clj
@@ -102,6 +102,7 @@
   (or (some-> req
               (find-and-auth ::auth/update)
               (merge (extract-recon req))
+              (update-in-if [:reconciliation/items] itms/resolve-refs)
               entities/put
               api/update-response)
       api/not-found))

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -271,6 +271,26 @@
   (with-context update-context
     (assert-blocked-update (update-reconciliation "jane@doe.com"))))
 
+(deftest a-user-can-add-a-new-item-when-updating-a-reconciliation
+  (with-context recon-context
+    (let [[_ created] (create-reconciliation "john@doe.com"
+                                             :body (build-recon :new))
+          new-item (first (select-recon-items))
+          body (-> created
+                   (dissoc :id)
+                   (assoc :reconciliation/items [(select-keys new-item [:id])]))
+          response (-> (request :patch (path :api
+                                             :reconciliations
+                                             (:id created))
+                                :content-type "application/edn"
+                                :body body
+                                :user (find-user "john@doe.com"))
+                       app
+                       parse-body)]
+      (is (http-success? response)
+          (str "adding a new (abbreviated) item on update should succeed: "
+               (:parsed-body response))))))
+
 (defn- get-reconciliations-by-status
   [email status]
   (let [account (find-account "Checking")]


### PR DESCRIPTION
## Summary
- Fixes Trello #281: a reconciliation could be saved once, but re-saving it (e.g. to add another checked item or mark it complete) failed with "All items must belong to the account being reconciled."
- Root cause: the `create` handler in `src/clj_money/api/reconciliations.clj` hydrates abbreviated `:reconciliation/items` (just `{:id ...}`, as sent by the client) via `itms/resolve-refs` before validation, but `update` never did — so any item not already tagged to the reconciliation being edited (e.g. a newly checked item on a second save) reached the `items-belong-to-account?` spec with no `:transaction-item/account`, and always failed.
- Fix: add the same `resolve-refs` step to `update`, mirroring `create`.

## Test plan
- [x] Added `a-user-can-add-a-new-item-when-updating-a-reconciliation`, which fails with the exact reported error before the fix and passes after.
- [x] `lein test :only clj-money.api.reconciliations-test` — 14/14 pass.
- [x] `lein test` — 917 tests, 0 failures; 248 pre-existing errors are all `PSQLException: connection attempt failed` from `-sql`-suffixed tests, caused by no local PostgreSQL server being available in this environment (unrelated to this change).
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb