### PR TITLE
Fix crash expanding a transaction form before an amount is entered

### DIFF
--- a/src/clj_money/decimal.cljc
+++ b/src/clj_money/decimal.cljc
@@ -102,7 +102,7 @@
             (.setScale n places BigDecimal/ROUND_HALF_UP))))
 
 #?(:cljs (def abs decimal/abs)
-   :clj  (def abs core/abs))
+   :clj  (defn abs [n] (when n (core/abs n))))
 
 (defn parse
    [s]

--- a/src/clj_money/transactions.cljc
+++ b/src/clj_money/transactions.cljc
@@ -700,12 +700,12 @@
 (defn unaccountify
   "Accepts an accountified transaction (with one quantity, one account, and
                                          one 'other' account) and returns a bilateral transaction"
-  [{:transaction/keys [quantity
-                       account]
-    :as trx}]
+  [trx]
   {:pre [(:transaction/account trx)]}
   ; accountified -> simple -> bilateral
-  (let [renames (if (if (left-side? account)
+  (let [trx (update trx :transaction/quantity #(or % d/zero))
+        {:transaction/keys [quantity account]} trx
+        renames (if (if (left-side? account)
                       (d/< d/zero quantity)
                       (d/< quantity d/zero))
                   {:transaction/account :transaction/debit-account

--- a/test/clj_money/transactions_test.cljc
+++ b/test/clj_money/transactions_test.cljc
@@ -133,6 +133,9 @@
                                                :account/type :expense}
                                :quantity (d -10)}]
       (is (= expected (trx/unaccountify simple)))
+      (testing "no quantity entered yet"
+        (is (some? (trx/unaccountify (dissoc simple :transaction/quantity)))
+            "It does not raise an exception when the quantity has not yet been entered"))
       (testing "two asset accounts"
         (is (= (assoc-in expected
                          [:transaction/items


### PR DESCRIPTION
## Summary
- Fixes a crash (`Uncaught TypeError: Cannot read properties of null (reading 'lessThan')`) when clicking the "expand" button on a new, simple transaction before an amount has been typed in.
- `unaccountify` compared `:transaction/quantity` (nil at that point) against zero via an unguarded decimal `<`. It now defaults a nil quantity to zero before the comparison and carries that default through the rest of the conversion.
- Also guards the JVM-side `d/abs` against `nil`, matching the ClojureScript version, which already handled it.

## Test plan
- [x] Added a regression test in `transactions_test.cljc` covering `unaccountify` with no quantity set yet
- [x] `lein test clj-money.transactions-test` — 16 tests, 45 assertions, 0 failures/errors
- [x] `clj-kondo --lint` on changed files — 0 errors/warnings
- [x] `lein test` (full suite) — 0 failures; the 248 errors present are pre-existing Postgres connection failures in this sandbox (no local DB available), unrelated to this change

Trello card: https://trello.com/c/ciCXBAes/280-unable-to-expand-transaction-form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb