### PR TITLE
Refresh the pending-scheduled-transaction nav badge after mutations

### DIFF
--- a/src/clj_money/app.cljs
+++ b/src/clj_money/app.cljs
@@ -4,7 +4,7 @@
             [clj-money.api.entities :as entities]
             [clj-money.api.scheduled-transactions :as sched-trxs]))
 
-(defn- load-pending-count []
+(defn load-pending-count []
   (try
     (sched-trxs/count
       {:pending true}

--- a/src/clj_money/views/scheduled.cljs
+++ b/src/clj_money/views/scheduled.cljs
@@ -19,6 +19,7 @@
             [dgknght.app-lib.bootstrap-5 :as bs]
             [clj-money.icons :refer [icon
                                      icon-with-text]]
+            [clj-money.app :refer [load-pending-count]]
             [clj-money.state :refer [app-state
                                      current-entity
                                      accounts
@@ -77,6 +78,7 @@
                       (swap! page-state #(-> %
                                              (update-sched-trans result)
                                              (update-in [:created] (fnil concat []) result)))
+                      (load-pending-count)
                       (notify/toast "Success" (if (empty? result)
                                                 "No transactions are ready to be created."
                                                 "The scheduled transactions where created")))]
@@ -245,6 +247,7 @@
       (sched-trans/save :callback -busy
                         :on-success (fn [_]
                                       (load-sched-trans page-state)
+                                      (load-pending-count)
                                       (swap! page-state dissoc :selected)))))
 
 (defn- adj-items


### PR DESCRIPTION
## Summary
- The nav bar badge showing the count of pending scheduled transactions was only ever fetched once, when the entity list first loaded (`clj-money.app/receive-entities` → `load-pending-count`).
- Creating a new scheduled transaction, or realizing existing ones, left the badge showing a stale count until the next full page reload.
- Made `load-pending-count` public and called it from the `on-success` handlers for both `save-sched-tran` (create/update) and `realize` in `views/scheduled.cljs`.

## Test plan
- [x] `clj-kondo --lint src:test` — 0 errors/warnings
- [x] `lein fig:test` — 105 tests, 370 assertions, 0 failures/errors (ClojureScript build compiles and passes)
- [x] Manually traced the reagent state flow: `state/pending-scheduled-count` is derefed reactively by the nav badge, so calling `load-pending-count` after a mutation is sufficient to refresh it — no further wiring needed.

Trello card: https://trello.com/c/M66nCOKr/283-the-pending-scheduled-trx-badge-does-not-update-when-a-scheduled-trx-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb