### PR TITLE
Filter realized-transaction response to only newly created transactions

### DIFF
--- a/src/clj_money/api/scheduled_transactions.clj
+++ b/src/clj_money/api/scheduled_transactions.clj
@@ -156,6 +156,8 @@
               realize-accounts
               sched-trans/realize
               put-many
+              (->> (filter (util/entity-type? :transaction))
+                   (sort-by :transaction/transaction-date t/before?))
               api/creation-response)
       api/not-found))
 

--- a/test/clj_money/api/scheduled_transactions_test.clj
+++ b/test/clj_money/api/scheduled_transactions_test.clj
@@ -319,6 +319,15 @@
 (deftest a-user-cannot-delete-a-scheduled-transaction-in-anothers-entity
   (assert-blocked-delete (delete-sched-tran "jane@doe.com")))
 
+(def ^:private realize-context
+  (conj update-context
+        #:transaction{:entity "Personal"
+                      :description "Existing Payment"
+                      :transaction-date (t/local-date 2016 1 15)
+                      :quantity 50M
+                      :debit-account "Rent"
+                      :credit-account "Checking"}))
+
 (defn- realize-trans
   [user-email]
   (let [sched-tran (find-scheduled-transaction "Paycheck")]
@@ -332,8 +341,17 @@
           parse-body))))
 
 (defn- assert-successful-realization
-  [response]
+  [{:as response :keys [parsed-body]}]
   (is (http-created? response))
+  (is (seq-of-maps-like?
+        [#:transaction{:description "Paycheck"
+                       :transaction-date (t/local-date 2016 2 1)
+                       :items [#:transaction-item{:quantity 1000M
+                                                  :action :debit}
+                               #:transaction-item{:quantity 1000M
+                                                  :action :credit}]}]
+        parsed-body)
+      "Only the newly created transaction is returned, not pre-existing ones")
   (is (seq-of-maps-like?
         [#:transaction{:description "Paycheck"
                        :transaction-date (t/local-date 2016 2 1)
@@ -357,7 +375,7 @@
       "The scheduled trx record is not updated with the last occurrence"))
 
 (deftest a-user-can-realize-a-scheduled-transaction-in-his-entity
-  (with-context update-context
+  (with-context realize-context
     (assert-successful-realization (realize-trans "john@doe.com"))))
 
 (deftest a-user-cannot-realize-a-scheduled-transaction-in-anothers-entity


### PR DESCRIPTION
## Summary
- Realizing a single scheduled transaction (the "auto create" lightning-bolt action on one scheduled transaction row) returned every entity touched by `with-delayed-propagation`'s account re-indexing — transaction-items, accounts, and entity records for *all* pre-existing transactions on the affected accounts — not just the transaction that was actually just created.
- `mass-realize` (the "realize all" action) already filtered/sorted its `put-many` result down to `:transaction` entities only; `realize` (the single-schedule action) never had that filter, so the client's "Created Transactions" table ended up showing many transactions the user hadn't just created.
- Applied the same `(filter (util/entity-type? :transaction)) (sort-by :transaction/transaction-date t/before?)` pipeline already used by `mass-realize` to `realize`.

## Test plan
- [x] Added a regression test (`realize-context` + updated `assert-successful-realization` in `scheduled_transactions_test.clj`) that seeds a pre-existing transaction on the same account, then asserts the realize response contains only the one newly created transaction
- [x] Verified the new test fails without the fix (`expected 1 items, but found 8`) and passes with it
- [x] `lein test clj-money.api.scheduled-transactions-test` — 14 tests, 45 assertions, 0 failures/errors
- [x] `clj-kondo --lint src:test` — 0 errors/warnings
- [x] `lein test` (full suite) — 0 failures; 248 errors are pre-existing Postgres connection failures unrelated to this change (same baseline as prior PRs in this session)

Trello card: https://trello.com/c/BfaYl7fD/278-check-the-query-that-returns-newly-created-transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb