### PR TITLE
Convert entities.schema/entities from a vector to a map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -163,7 +163,7 @@
                    lein-doo]]
                  [lambdaisland/uri "1.19.155"]
                  [com.taoensso/carmine "3.5.0" :exclusions [org.clojure/tools.reader commons-codec]]
-                 [stowaway "0.2.13" :exclusions [com.github.seancorfield/honeysql org.clojure/spec.alpha org.clojure/clojure potemkin org.clojure/core.specs.alpha org.clojure/tools.logging]]
+                 [stowaway "0.2.14" :exclusions [com.github.seancorfield/honeysql org.clojure/spec.alpha org.clojure/clojure potemkin org.clojure/core.specs.alpha org.clojure/tools.logging]]
                  [io.opentelemetry/opentelemetry-api "1.64.0"]
                  [org.clojure/data.csv "1.1.1"]
                  [org.clj-commons/hickory "0.7.7"]
@@ -222,7 +222,13 @@
                                  (and (not (:multi-threaded m))
                                       (= :sql (:strategy m))))
                    :multi-threaded :multi-threaded
-                   :single-threaded (complement :multi-threaded)}
+                   :single-threaded (complement :multi-threaded)
+                   :entities [(fn [n & _]
+                                (re-find #"^clj-money\.entities\." (name n)))
+                              (constantly true)]
+                   :api [(fn [n & _]
+                           (re-find #"^clj-money\.api\." (name n)))
+                         (constantly true)]}
   :cloverage {:line-fail-threshold 90
               :form-fail-threshold 80
               :low-watermark 93

--- a/src/clj_money/db/datomic.clj
+++ b/src/clj_money/db/datomic.clj
@@ -182,15 +182,23 @@
         x)
       (f x))))
 
-(def ^:private ref-keys
-  schema/entity-ref-keys)
+(def ref-id (some-fn :id identity))
+
+(def entity-ref-keys
+  (->> schema/entities
+       (mapcat (fn [[id {:keys [refs]}]]
+                 (->> refs
+                      (remove :component)
+                      (map #(keyword (name id)
+                                     (name (ref-id %)))))))
+       set))
 
 (defn- put*
   [entities {:keys [api]} {:keys [tx-meta]}]
   (let [prepped (->> entities
                      (map (pass-through #(util/+id % (comp str random-uuid))))
                      (mapcat (pass-through deconstruct :plural true))
-                     (map (pass-through (datomize {:ref-keys ref-keys})))
+                     (map (pass-through (datomize {:ref-keys entity-ref-keys})))
                      (mapcat #(prep-for-put % api))
                      vec)
         tx-data (cond-> prepped

--- a/src/clj_money/db/datomic/queries.clj
+++ b/src/clj_money/db/datomic/queries.clj
@@ -1,28 +1,10 @@
 (ns clj-money.db.datomic.queries
   (:require [clojure.pprint :refer [pprint]]
-            [clojure.set :as set]
             [stowaway.datalog :as dtl]
             [clj-money.entities.schema :as schema]))
 
-; TODO: reconcile this with the schema namespace
-(def relationships
-  ; Some relationships work differently in datomic compare to
-  ; a relational database. Here we reverse the ones that work
-  ; differently
-  (set/union
-    (set/difference
-      schema/relationships
-      #{[:budget :budget-item]
-        [:lot :lot-note]
-        [:transaction :lot-item]
-        [:transaction :transaction-item]})
-    #{[:budget-item :budget :items]
-      [:lot :lot-note :lots]
-      [:lot-item :transaction :lot-items]
-      [:transaction-item :transaction :items]}))
-
 (def ^:private default-opts
-  {:relationships relationships
+  {:relationships schema/relationships
    :query-prefix [:query]})
 
 (defn apply-criteria

--- a/src/clj_money/db/sql.clj
+++ b/src/clj_money/db/sql.clj
@@ -56,10 +56,10 @@
                                        (name k)))))))
 
 (def ^:private primary-keys
-  (->> schema/entities
-       (filter :primary-key)
+  (->> (schema/build :sql)
+       (filter (comp :primary-key second))
        (map (comp append-qualifiers
-                  (juxt :id :primary-key)))
+                  (juxt first (comp :primary-key second))))
        (into {})))
 
 (def ^:private reconstruction-rules
@@ -207,7 +207,7 @@
         [(str (name (:id ref)) "-id")]))))
 
 (defn- build-attributes
-  [[t fields refs]]
+  [[t {:keys [fields refs]}]]
   (let [attrs (->> refs
                    (mapcat ref-to-attrs)
                    (map #(keyword (name t) (name %)))
@@ -217,11 +217,11 @@
                    set)]
     [t (conj attrs :id)]))
 
+; TODO: These customizations should be moved into the overrides in the schema ns
 (def attributes
   "A map of entity types to attributes for the type"
-  (-> (->> schema/entities
-           (map (comp build-attributes
-                      (juxt :id :fields :refs)))
+  (-> (->> (schema/build :sql)
+           (map build-attributes)
            (into {}))
       (update-in [:account-item]
                  conj
@@ -293,8 +293,8 @@
 
 (def ^:private sqlize
   (types/sqlize
-    {:ref-keys (->> schema/entities
-                    (mapcat (fn [{:keys [refs id]}]
+    {:ref-keys (->> (schema/build :sql)
+                    (mapcat (fn [[id {:keys [refs]}]]
                               (map (fn [ref]
                                      [(keyword (name id)
                                                (name (schema/ref-id ref)))
@@ -305,6 +305,24 @@
                                    refs)))
                     (into {}))}))
 
+(defn- remove-redundant-select-also
+  "If any attributes in the :select-also value belongs to the
+  primary target of the query, they can be removed because they
+  are covered by the * used to get the entire row anyway."
+  [{:keys [select-also entity-type] :as opts}]
+  (if select-also
+    (let [t (name entity-type)]
+      (update-in opts
+                 [:select-also]
+                 (comp (fn [ks]
+                         (remove #(= t (namespace %))
+                                 ks))
+                       (fn [ks]
+                         (if (sequential? ks)
+                           ks
+                           [ks])))))
+    opts))
+
 (defn- make-query
   [criteria {:as options
              :keys [include-children?
@@ -314,11 +332,12 @@
   (-> criteria
       (crt/apply-to sqlize)
       (criteria->query
-        (cond-> (assoc options
-                       :quoted? true
-                       :column-fn ->snake_case
-                       :table-fn ->snake_case
-                       :target entity-type)
+        (cond-> (-> options
+                    remove-redundant-select-also
+                    (assoc :quoted? true
+                           :column-fn ->snake_case
+                           :table-fn ->snake_case
+                           :target entity-type))
           nil-replacements (assoc :nil-replacements
                                   (update-keys nil-replacements
                                                ->snake-case))
@@ -347,8 +366,8 @@
        attr-type)]))
 
 (def ^:private sql-ref-keys
-  (->> schema/entities
-       (mapcat (fn [{:keys [refs id]}]
+  (->> (schema/build :sql)
+       (mapcat (fn [[id {:keys [refs]}]]
                  (map #(vector id %) refs)))
        (map ref-spec->sql-key)
        (into {})))

--- a/src/clj_money/db/sql/queries.clj
+++ b/src/clj_money/db/sql/queries.clj
@@ -7,9 +7,10 @@
 
 (def ^:private joins
   (merge
-    (->> schema/entities
-         (filter #(some map? (:refs %)))
-         (mapcat (fn [{:keys [refs id]}]
+    (->> (schema/build :sql)
+         (filter (fn [[_ e]]
+                   (some map? (:refs e))))
+         (mapcat (fn [[id {:keys [refs]}]]
                    (->> refs
                         (filter (every-pred map?
                                             :columns))
@@ -20,8 +21,15 @@
     ; Explicit JOIN for array-based relationships
     {[:lot :lot-note] [[:id [:any :lot-note/lot-ids]]]}))
 
+(def ^:private relationships
+  (->> (schema/build :sql)
+       (mapcat (fn [[id {:keys [refs]}]]
+                 (map #(vector (schema/relationship-ref-type %) id)
+                      refs)))
+       set))
+
 (def ^:private default-options
-  {:relationships schema/relationships
+  {:relationships relationships
    :joins joins})
 
 (def ^:private bisect

--- a/src/clj_money/db/sql/types.clj
+++ b/src/clj_money/db/sql/types.clj
@@ -5,6 +5,7 @@
                                   postwalk]]
             [clojure.spec.alpha :as s]
             [jsonista.core :as json]
+            [cheshire.generate :refer [add-encoder]]
             [java-time.api :as t]
             [next.jdbc.result-set :as rs]
             [next.jdbc.prepare :as p]
@@ -50,6 +51,14 @@
      id
      (->QualifiedID id entity-type))))
 
+; budddy.sign still uses Cheshire, so we still need to be able to
+; serialize the ID with that library
+(add-encoder QualifiedID
+             (fn [id gen]
+               (.writeString gen (str "#clj-money/qid \""
+                                      id
+                                      "\""))))
+
 (defmethod print-method QualifiedID
   [this ^java.io.Writer w]
   (doto w
@@ -57,10 +66,15 @@
     (.write (str this))
     (.write "\"")))
 
+(def ^:private qid-patterns
+  [#"\A#clj-money\/qid \"(\d+):([a-z\-]+)?\"\z"
+   #"\A(\d+)(:[a-z\-z]+)?\z"])
+
 (defn unserialize-qid
   [s]
   (when-let [match (when (string? s)
-                     (re-find #"\A(\d+):([a-z\-]+)?\z" s))]
+                     (some #(re-find % s)
+                           qid-patterns))]
     (->QualifiedID (parse-long (nth match 1))
                    (keyword (nth match 2)))))
 
@@ -403,8 +417,8 @@
     (into-array (map name coll))))
 
 (def read-coercions
-  (->> schema/entities
-       (mapcat (fn [{:keys [id fields]}]
+  (->> (schema/build :sql)
+       (mapcat (fn [[id {:keys [fields]}]]
                  (->> fields
                       (keep (fn [{field-id :id type :type}]
                               (let [k (keyword (name id) (name field-id))]
@@ -416,8 +430,8 @@
        (into {})))
 
 (def save-coercions
-  (->> schema/entities
-       (mapcat (fn [{:keys [id fields]}]
+  (->> (schema/build :sql)
+       (mapcat (fn [[id {:keys [fields]}]]
                  (->> fields
                       (keep (fn [{field-id :id type :type}]
                               (let [k (keyword (name id) (name field-id))]

--- a/src/clj_money/entities/schema.cljc
+++ b/src/clj_money/entities/schema.cljc
@@ -26,300 +26,322 @@
                          :min-count 1
                          :kind set?))
 (s/def ::primary-key (s/coll-of keyword?))
-(s/def ::entity (s/keys :req-un [::id
-                                 ::fields]
+(s/def ::entity (s/keys :req-un [::fields]
                         :opt-un [::refs
                                  ::primary-key]))
-(def entities
-  [{:id :user
-    :fields #{{:id :email
-               :type :string}
-              {:id :password
-               :type :string}
-              {:id :first-name
-               :type :string}
-              {:id :last-name
-               :type :string}
-              {:id :password-reset-token
-               :type :string}
-              {:id :token-expires-at
-               :type :date-time}
-              {:id :roles
-               :type :set}}}
-   {:id :identity
-    :fields #{{:id :provider
-               :type :keyword}
-              {:id :provider-id
-               :type :string}}
-    :refs #{:user}}
-   {:id :import
-    :fields #{{:id :entity-name
-               :type :string}
-              {:id :image-ids
-               :type :string}
-              {:id :options
-               :type :map}
-              {:id :progress
-               :type :map
-               :transient? true}}
-    :refs #{:user
-            {:id :images
-             :type [:image]}}} ; the vector indicates a vector of images
-   {:id :image
-    :fields #{{:id :original-filename
-               :type :string}
-              {:id :uuid
-               :type :string}
-              {:id :content-type
-               :type :string}}
-    :refs #{:user}}
-   {:id :entity
-    :fields #{{:id :name
-               :type :string}
-              {:id :price-date-range
-               :type :tuple
-               :transient? true}
-              {:id :transaction-date-range
-               :type :tuple
-               :transient? true}
-              {:id :settings
-               :type :map}}
-    :refs #{:user}}
-   {:id :grant
-    :fields #{{:id :permissions
-               :type :map}}
-    :refs #{:user :entity}}
-   {:id :commodity
-    :fields #{{:id :type
-               :type :keyword}
-              {:id :name
-               :type :string}
-              {:id :symbol
-               :type :string}
-              {:id :exchange
-               :type :keyword}
-              {:id :price-config
-               :type :map}
-              {:id :shares-owned
-               :type :decimal}
-              {:id :price-date-range
-               :type :tuple
-               :transient? true}}
-    :refs #{:entity}}
-   {:id :price
-    :primary-key [:trade-date :id]
-    :fields #{{:id :trade-date
-               :type :date}
-              {:id :value
-               :type :decimal}}
-    :refs #{:commodity}}
-   {:id :account
-    :fields #{{:id :name
-               :type :string}
-              {:id :type
-               :type :keyword}
-              {:id :allocations
-               :type :map}
-              {:id :user-tags
-               :type :set}
-              {:id :system-tags
-               :type :set}
-              {:id :hidden
-               :type :boolean}
-              {:id :quantity
-               :type :decimal
-               :transient? true}
-              {:id :value
-               :type :decimal
-               :transient? true}
-              {:id :price-as-of
-               :type :decimal
-               :transient? true}
-              {:id :transaction-date-range
-               :type :tuple
-               :transient? true}}
-    :refs #{:entity
-            :commodity
-            {:id :parent
-             :type :account}}}
-   {:id :transaction
-    :fields #{{:id :transaction-date
-               :type :date}
-              {:id :description
-               :type :string}
-              {:id :memo
-               :type :string}
-              {:id :value
-               :type :decimal
-               :transient? true}
-              {:id :attachment-count
-               :type :string
-               :transient? true}
-              {:id :items
-               :type :vector}}
-    :refs #{:entity
-            :scheduled-transaction}}
-   {:id :transaction-item
-    :fields #{{:id :quantity
-               :type :decimal}
-              {:id :value
-               :type :decimal}
-              {:id :balance
-               :type :decimal}
-              {:id :index
-               :type :integer}
-              {:id :action
-               :type :keyword}
-              {:id :memo
-               :type :string}}
-    :refs #{:account
-            :reconciliation
-            :transaction}}
-   {:id :lot
-    :fields #{{:id :shares-purchased
-               :type :decimal}
-              {:id :purchase-date
-               :type :date}
-              {:id :purchase-price
-               :type :decimal}
-              {:id :shares-owned
-               :type :string
-               :transient? true}}
-    :refs #{:account
-            :commodity}}
-   {:id :lot-note
-    :fields #{{:id :transaction-date
-               :type :date}
-              {:id :memo
-               :type :string}}
-    :refs #{{:id :lots :type [:lot]}}}
-   {:id :lot-item
-    :fields #{{:id :action
-               :type :keyword}
-              {:id :shares
-               :type :decimal}
-              {:id :price
-               :type :decimal}}
-    :refs #{:lot
-            :transaction}}
-   {:id :budget
-    :fields #{{:id :name
-               :type :string}
-              {:id :start-date
-               :type :date}
-              {:id :period
-               :type :tuple}
-              {:id :end-date
-               :type :date
-               :transient? true}
-              {:id :auto-create-start-date
-               :type :date
-               :transient? true}}
-    :refs #{:entity}}
-   {:id :budget-item
-    :fields #{{:id :periods
-               :type :vector}
-              {:id :spec
-               :type :map}}
-    :refs #{:budget
-            :account}}
-   {:id :scheduled-transaction
-    :fields #{{:id :description
-               :type :string}
-              {:id :start-date
-               :type :date}
-              {:id :date-spec
-               :type :map}
-              {:id :end-date
-               :type :date}
-              {:id :enabled
-               :type :boolean}
-              {:id :period
-               :type :tuple}
-              {:id :memo
-               :type :string}
-              {:id :last-occurrence
-               :type :string
-               :transient? true}
-              {:id :items
-               :type :vector}}
-    :refs #{:entity}}
-   {:id :scheduled-transaction-item
-    :fields #{{:id :action
-               :type :keyword}
-              {:id :quantity
-               :type :decimal}
-              {:id :memo
-               :type :string}}
-    :refs #{:scheduled-transaction
-            :account}}
-   {:id :attachment
-    :fields #{{:id :caption
-               :type :string}}
-    :refs #{:image
-            :transaction}}
-   {:id :reconciliation
-    :fields #{{:id :status
-               :type :keyword}
-              {:id :balance
-               :type :decimal}
-              {:id :end-of-period
-               :type :date}
-              {:id :items
-               :type :vector}}
-    :refs #{:account}}
-   {:id :cached-price
-    :primary-key [:trade-date :id]
-    :fields #{{:id :trade-date
-               :type :date}
-              {:id :symbol
-               :type :string}
-              {:id :exchange
-               :type :keyword}
-              {:id :value
-               :type :decimal}}}
-   {:id :invitation
-    :fields #{{:id :recipient
-               :type :string}
-              {:id :note
-               :type :string}
-              {:id :status
-               :type :keyword}
-              {:id :token
-               :type :string}
-              {:id :expires-at
-               :type :date-time}}
-    :refs #{{:id :invited-by :type :user}
-            :user}}])
+(s/def ::entities (s/map-of keyword? ::entity))
 
-(assert (s/valid? (s/coll-of ::entity) entities)
+(def entities
+  {:user {:fields #{{:id :email
+                     :type :string}
+                    {:id :password
+                     :type :string}
+                    {:id :first-name
+                     :type :string}
+                    {:id :last-name
+                     :type :string}
+                    {:id :password-reset-token
+                     :type :string}
+                    {:id :token-expires-at
+                     :type :date-time}
+                    {:id :roles
+                     :type :set}}}
+   :identity {:fields #{{:id :provider
+                         :type :keyword}
+                        {:id :provider-id
+                         :type :string}}
+              :refs #{:user}}
+   :import {:fields #{{:id :entity-name
+                       :type :string}
+                      {:id :image-ids
+                       :type :string}
+                      {:id :options
+                       :type :map}
+                      {:id :progress
+                       :type :map
+                       :transient? true}}
+            :refs #{:user
+                    {:id :images
+                     :type [:image]}}} ; the vector indicates a vector of images
+   :image {:fields #{{:id :original-filename
+                      :type :string}
+                     {:id :uuid
+                      :type :string}
+                     {:id :content-type
+                      :type :string}}
+           :refs #{:user}}
+   :entity {:fields #{{:id :name
+                       :type :string}
+                      {:id :price-date-range
+                       :type :tuple
+                       :transient? true}
+                      {:id :transaction-date-range
+                       :type :tuple
+                       :transient? true}
+                      {:id :settings
+                       :type :map}}
+            :refs #{:user}}
+   :grant {:fields #{{:id :permissions
+                      :type :map}}
+           :refs #{:user :entity}}
+   :commodity {:fields #{{:id :type
+                          :type :keyword}
+                         {:id :name
+                          :type :string}
+                         {:id :symbol
+                          :type :string}
+                         {:id :exchange
+                          :type :keyword}
+                         {:id :price-config
+                          :type :map}
+                         {:id :shares-owned
+                          :type :decimal}
+                         {:id :price-date-range
+                          :type :tuple
+                          :transient? true}}
+               :refs #{:entity}}
+   :price {:primary-key [:trade-date :id]
+           :fields #{{:id :trade-date
+                      :type :date}
+                     {:id :value
+                      :type :decimal}}
+           :refs #{:commodity}}
+   :account {:fields #{{:id :name
+                        :type :string}
+                       {:id :type
+                        :type :keyword}
+                       {:id :allocations
+                        :type :map}
+                       {:id :user-tags
+                        :type :set}
+                       {:id :system-tags
+                        :type :set}
+                       {:id :hidden
+                        :type :boolean}
+                       {:id :quantity
+                        :type :decimal
+                        :transient? true}
+                       {:id :value
+                        :type :decimal
+                        :transient? true}
+                       {:id :price-as-of
+                        :type :decimal
+                        :transient? true}
+                       {:id :transaction-date-range
+                        :type :tuple
+                        :transient? true}}
+             :refs #{:entity
+                     :commodity
+                     {:id :parent
+                      :type :account}}}
+   :transaction {:fields #{{:id :transaction-date
+                            :type :date}
+                           {:id :description
+                            :type :string}
+                           {:id :memo
+                            :type :string}
+                           {:id :value
+                            :type :decimal
+                            :transient? true}
+                           {:id :attachment-count
+                            :type :string
+                            :transient? true}
+                           {:id :items
+                            :type :vector}}
+                 :refs #{:entity
+                         :scheduled-transaction
+                         {:id :items
+                          :type [:transaction-item]
+                          :component true}
+                         {:id :lot-items
+                          :type [:lot-item]
+                          :component true}}}
+   :transaction-item {:fields #{{:id :quantity
+                                 :type :decimal}
+                                {:id :value
+                                 :type :decimal}
+                                {:id :balance
+                                 :type :decimal}
+                                {:id :index
+                                 :type :integer}
+                                {:id :action
+                                 :type :keyword}
+                                {:id :memo
+                                 :type :string}}
+                      :refs #{:account
+                              :reconciliation}}
+   :lot {:fields #{{:id :shares-purchased
+                    :type :decimal}
+                   {:id :purchase-date
+                    :type :date}
+                   {:id :purchase-price
+                    :type :decimal}
+                   {:id :shares-owned
+                    :type :string
+                    :transient? true}}
+         :refs #{:account
+                 :commodity}}
+   :lot-note {:fields #{{:id :transaction-date
+                         :type :date}
+                        {:id :memo
+                         :type :string}}
+              :refs #{{:id :lots :type [:lot]}}}
+   :lot-item {:fields #{{:id :action
+                         :type :keyword}
+                        {:id :shares
+                         :type :decimal}
+                        {:id :price
+                         :type :decimal}}
+              :refs #{:lot}}
+   :budget {:fields #{{:id :name
+                       :type :string}
+                      {:id :start-date
+                       :type :date}
+                      {:id :period
+                       :type :tuple}
+                      {:id :end-date
+                       :type :date
+                       :transient? true}
+                      {:id :auto-create-start-date
+                       :type :date
+                       :transient? true}}
+            :refs #{:entity
+                    {:id :items
+                     :type [:budget-item]
+                     :component true}}}
+   :budget-item {:fields #{{:id :periods
+                            :type :vector}
+                           {:id :spec
+                            :type :map}}
+                 :refs #{:account}}
+   :scheduled-transaction {:fields #{{:id :description
+                                      :type :string}
+                                     {:id :start-date
+                                      :type :date}
+                                     {:id :date-spec
+                                      :type :map}
+                                     {:id :end-date
+                                      :type :date}
+                                     {:id :enabled
+                                      :type :boolean}
+                                     {:id :period
+                                      :type :tuple}
+                                     {:id :memo
+                                      :type :string}
+                                     {:id :last-occurrence
+                                      :type :string
+                                      :transient? true}
+                                     {:id :items
+                                      :type :vector}}
+                           :refs #{:entity
+                                   {:id :items
+                                    :type [:scheduled-transaction-item]
+                                    :component true}}}
+   :scheduled-transaction-item {:fields #{{:id :action
+                                           :type :keyword}
+                                          {:id :quantity
+                                           :type :decimal}
+                                          {:id :memo
+                                           :type :string}}
+                                :refs #{:account}}
+   :attachment {:fields #{{:id :caption
+                           :type :string}}
+                :refs #{:image
+                        :transaction}}
+   :reconciliation {:fields #{{:id :status
+                               :type :keyword}
+                              {:id :balance
+                               :type :decimal}
+                              {:id :end-of-period
+                               :type :date}
+                              {:id :items
+                               :type :vector}}
+                    :refs #{:account}}
+   :cached-price {:primary-key [:trade-date :id]
+                  :fields #{{:id :trade-date
+                             :type :date}
+                            {:id :symbol
+                             :type :string}
+                            {:id :exchange
+                             :type :keyword}
+                            {:id :value
+                             :type :decimal}}}
+   :invitation {:fields #{{:id :recipient
+                           :type :string}
+                          {:id :note
+                           :type :string}
+                          {:id :status
+                           :type :keyword}
+                          {:id :token
+                           :type :string}
+                          {:id :expires-at
+                           :type :date-time}}
+                :refs #{{:id :invited-by :type :user}
+                        :user}}})
+
+(assert (s/valid? ::entities entities)
         "The schema is not valid")
+
+(def ^:private overrides
+  {:sql {:transaction {:refs #{:entity
+                               :scheduled-transaction}}
+         :transaction-item {:refs #{:transaction
+                                    :account
+                                    :reconciliation}}
+
+         :lot-item {:refs #{:lot
+                            :transaction}}
+
+         :scheduled-transaction {:refs #{:entity}}
+         :scheduled-transaction-item {:refs #{:scheduled-transaction
+                                              :account}}
+
+         :budget {:refs #{:entity}}
+         :budget-item {:refs #{:budget
+                               :account}}}})
+
+(defn- resolve-merge-conflict
+  [v1 v2]
+  (if (set? v1)
+    v2
+    (merge-with resolve-merge-conflict v1 v2)))
+
+(defn build
+  [override]
+  (merge-with resolve-merge-conflict
+              entities
+              (overrides override)))
 
 (def ref-id (some-fn :id identity))
 
-(def entity-ref-keys
-  (->> entities
-       (mapcat (fn [{:keys [refs id]}]
-                 (map (fn [ref]
-                        (keyword (name id)
-                                 (name (ref-id ref))))
-                      refs)))
-       set))
-
-(defn- relationship-ref-type
-  "Returns the entity type for a relationship.
-  For plural refs like {:id :lots :type [:lot]}, returns :lot.
-  For simple refs like :lot, returns :lot."
+(defn relationship-ref-type
+  "Returns the entity type for a relationship."
   [ref]
   (if (and (map? ref) (vector? (:type ref)))
     (first (:type ref))
     (ref-id ref)))
 
+(defn relationship-tuple
+  "Returns a function that takes an entity reference and
+  returns a type with the referenced type in the 1st position,
+  the referencing type in the 2nd position, and an optional
+  attribute override in the 3rd position (if the type of the
+  referenced entity is not also the attribute)"
+  [id]
+  (fn [ref]
+    (if (keyword? ref)
+      [ref id]
+      (if-let [t (:type ref)]
+        [(if (vector? t) (first t) t) id (:id ref)]
+        [(:id ref) id]))))
+
+(defn- relationship-tuples
+  [[id {:keys [refs]}]]
+  (map (relationship-tuple id) refs))
+
 (def relationships
   (->> entities
-       (mapcat (fn [{:keys [id refs]}]
-                 (map #(vector (relationship-ref-type %) id)
-                      refs)))
+       (mapcat relationship-tuples)
        set))
 
 (defn- extract-attributes
@@ -335,7 +357,8 @@
 
 (def attributes
   (->> entities
-       (map (juxt :id extract-attributes))
+       (map (juxt first (comp extract-attributes
+                              second)))
        (into {})))
 
 (defn- extract-reference-attributes
@@ -347,7 +370,8 @@
 
 (def reference-attributes
   (->> entities
-       (map (juxt :id extract-reference-attributes))
+       (map (juxt first (comp extract-reference-attributes
+                              second)))
        (into {})))
 
 (defn- simplify-references

--- a/src/clj_money/tasks.clj
+++ b/src/clj_money/tasks.clj
@@ -250,7 +250,7 @@
       (System/exit 0))))
 
 (defn- er-entity
-  [{:keys [id fields]}]
+  [[id {:keys [fields]}]]
   (concat
     [(str "  " (name id) " \u007B")]
     (map (fn [{:keys [id type]}]
@@ -259,7 +259,7 @@
     ["  \u007D"]))
 
 (defn- er-relationships
-  [{:keys [refs id]}]
+  [[id {:keys [refs]}]]
   (map (fn [ref]
          (let [ref-name (if (keyword? ref)
                           (name ref)

--- a/src/clj_money/util.cljc
+++ b/src/clj_money/util.cljc
@@ -67,9 +67,7 @@
           v))
 
 (def entity-types
-  (->> schema/entities
-       (map :id)
-       set))
+  (->> schema/entities keys set))
 
 (def valid-entity-type? entity-types)
 

--- a/src/clj_money/web/server.clj
+++ b/src/clj_money/web/server.clj
@@ -25,6 +25,8 @@
                                           wrap-format]]
             [clj-money.entities :as entities]
             [clj-money.db.ref]
+            [clj-money.db.sql.ref]
+            [clj-money.db.datomic.ref]
             [clj-money.entities.ref]
             [clj-money.api.users :as users-api]
             [clj-money.api.imports :as imports-api]

--- a/test/clj_money/api/transaction_items_test.clj
+++ b/test/clj_money/api/transaction_items_test.clj
@@ -168,39 +168,50 @@
 (deftest a-user-can-get-a-list-of-transaction-items-in-his-entity
   (with-context context
     (testing "default format (edn)"
-      (assert-successful-list (get-a-list "john@doe.com"))
-      (is (= (util/->entity-ref
-               (find-transaction
-                 [(t/local-date 2017 01 29)
-                  "Kroger"]))
-             (-> (get-a-list "john@doe.com")
-                 :parsed-body
-                 first
-                 :transaction-item/transaction))
-          "The transaction is included"))
+      (let [{:as res :keys [parsed-body]} (get-a-list "john@doe.com")]
+        (assert-successful-list res)
+        (is (= (util/->entity-ref
+                 (find-transaction
+                   [(t/local-date 2017 01 29)
+                    "Kroger"]))
+               (-> parsed-body
+                   first
+                   :transaction-item/transaction))
+            "The transaction is included")))
     (testing "json format"
-      (assert-successful-list
-        (get-a-list "john@doe.com" :content-type "application/json")
-        :expected [{:description "Kroger"
-                    :quantity "100.00"
-                    :action "credit"
-                    :_type "transaction-item"}
-                   {:description "Kroger"
-                    :quantity "100.00"
-                    :action "credit"
-                    :_type "transaction-item"}
-                   {:description "Paycheck"
-                    :quantity "1,000.00"
-                    :action "debit"
-                    :_type "transaction-item"}
-                   {:description "Kroger"
-                    :quantity "100.00"
-                    :action "credit"
-                    :_type "transaction-item"}
-                   {:description "Kroger"
-                    :quantity "100.00"
-                    :action "credit"
-                    :_type "transaction-item"}]))))
+      (let [{:as res :keys [parsed-body]} (get-a-list "john@doe.com"
+                                                      :content-type
+                                                      "application/json")]
+        (assert-successful-list
+          res
+          :expected [{:description "Kroger"
+                      :quantity "100.00"
+                      :action "credit"
+                      :_type "transaction-item"}
+                     {:description "Kroger"
+                      :quantity "100.00"
+                      :action "credit"
+                      :_type "transaction-item"}
+                     {:description "Paycheck"
+                      :quantity "1,000.00"
+                      :action "debit"
+                      :_type "transaction-item"}
+                     {:description "Kroger"
+                      :quantity "100.00"
+                      :action "credit"
+                      :_type "transaction-item"}
+                     {:description "Kroger"
+                      :quantity "100.00"
+                      :action "credit"
+                      :_type "transaction-item"}])
+        (is (= (util/->entity-ref
+                 (find-transaction
+                   [(t/local-date 2017 01 29)
+                    "Kroger"]))
+               (-> parsed-body
+                   first
+                   :transaction))
+            "The transaction is included")))))
 
 (deftest a-user-cannot-get-a-list-of-transaction-items-in-anothers-entity
   (with-context context

--- a/test/clj_money/entities/budget_items_test.clj
+++ b/test/clj_money/entities/budget_items_test.clj
@@ -88,8 +88,8 @@
     (assert-updated
       (find-budget "2016")
       {:budget/items [(assoc (attributes)
-                           :budget-item/spec {:start-date (t/local-date 2016 1 1)
-                                              :round-to 2})]})))
+                             :budget-item/spec {:start-date (t/local-date 2016 1 1)
+                                                :round-to 2})]})))
 
 (def ^:private existing-context
   (conj basic-context


### PR DESCRIPTION
## Summary
- Refactor `clj-money.entities.schema/entities` from a vector of entity maps to a map keyed by entity id.
- Add a `schema/build`/`overrides` mechanism so SQL and Datomic can each layer storage-specific relationship differences (e.g. `transaction-item`'s refs) over the shared base schema, replacing ad-hoc `:sql/refs`/`:datomic/refs` keys.
- Add a `:component true` flag on parent-owned child refs (e.g. `transaction`'s items) so relationship direction can be derived correctly for both storage backends.
- Fix `tasks.clj`'s `er-diagram` task, which would otherwise silently break once `schema/entities` became a map (destructuring a `MapEntry` as `{:keys [id fields]}` returns `nil`).
- Roll in a couple of small fixes that landed in the same original commit as the conversion: JSON encoding for `QualifiedID` via Cheshire (needed because `buddy.sign` still uses it) and removal of redundant `:select-also` columns already covered by `SELECT *`.

## Test plan
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [x] `lein test` — all non-database tests pass; `*-sql` dbtests error only on `UnknownHostException: sql` (no Postgres reachable in this sandbox, not a code issue)
- [ ] Run `lein er-diagram` and the full suite against a real Postgres/Datomic instance to confirm the map-shape fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb