### PR TITLE
Add a purge-entity operation to completely remove an entity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -198,6 +198,7 @@
             "account-report"        ["run" "-m" "clj-money.tasks/account-report"]
             "export-user-tags"      ["run" "-m" "clj-money.tasks/export-user-tags"]
             "import-user-tags"      ["run" "-m" "clj-money.tasks/import-user-tags"]
+            "purge-entity"          ["run" "-m" "clj-money.tasks/purge-entity"]
             "er-diagram"            ["run" "-m" "clj-money.tasks/er-diagram"]
             "re-index"              ["run" "-m" "clj-money.tasks/re-index"]
             "routes"                ["run" "-m" "clj-money.repl/print-routes"]

--- a/resources/migrations/20260715000000_cascade_transaction_item_account_delete.down.sql
+++ b/resources/migrations/20260715000000_cascade_transaction_item_account_delete.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.transaction_item
+  DROP CONSTRAINT transaction_item_account_id_fkey;
+
+ALTER TABLE public.transaction_item
+  ADD CONSTRAINT transaction_item_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.account(id);

--- a/resources/migrations/20260715000000_cascade_transaction_item_account_delete.up.sql
+++ b/resources/migrations/20260715000000_cascade_transaction_item_account_delete.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.transaction_item
+  DROP CONSTRAINT transaction_item_account_id_fkey;
+
+ALTER TABLE public.transaction_item
+  ADD CONSTRAINT transaction_item_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.account(id) ON DELETE CASCADE;

--- a/resources/migrations/20260716000000_purge_lot_notes_on_lot_delete.down.sql
+++ b/resources/migrations/20260716000000_purge_lot_notes_on_lot_delete.down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS trg_delete_orphaned_lot_notes ON public.lot;
+DROP FUNCTION IF EXISTS public.delete_orphaned_lot_notes();

--- a/resources/migrations/20260716000000_purge_lot_notes_on_lot_delete.up.sql
+++ b/resources/migrations/20260716000000_purge_lot_notes_on_lot_delete.up.sql
@@ -1,0 +1,14 @@
+CREATE FUNCTION public.delete_orphaned_lot_notes()
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    DELETE FROM lot_note WHERE OLD.id = ANY(lot_ids);
+    RETURN OLD;
+END;
+$$;
+ALTER FUNCTION public.delete_orphaned_lot_notes() OWNER TO ddl_user;
+CREATE TRIGGER trg_delete_orphaned_lot_notes
+    BEFORE DELETE ON public.lot
+    FOR EACH ROW
+    EXECUTE FUNCTION public.delete_orphaned_lot_notes();

--- a/src/clj_money/db.clj
+++ b/src/clj_money/db.clj
@@ -18,6 +18,7 @@
   (select [this criteria options] "Retrieves entities from the data store")
   (update [this changes criteria] "Performs a batch data update")
   (delete [this entities] "Removes entities from the data store")
+  (purge! [this entity] "Remove the entity entirely from the data store")
   (history [this entity-id attr]
     "Returns the history of values for the attribute of the given entity")
   (close [this] "Releases an resources held by the instance")
@@ -36,9 +37,10 @@
 
 (defmacro with-storage
   [bindings & body]
-  `(let [storage# (if (satisfies? Storage ~(first bindings))
-                    ~(first bindings)
-                    (reify-storage ~(first bindings)))]
+  `(let [cfg# ~(first bindings)
+         storage# (if (satisfies? Storage cfg#)
+                    cfg#
+                    (reify-storage cfg#))]
      (try
        (binding [*storage* storage#]
          ~@body)
@@ -75,6 +77,12 @@
                                   prefix
                                   (-> entities first util/entity-type))]
         (delete storage entities)))
+
+    (purge! [_ entity]
+      (with-tracing [span (format "%s/purge! %s"
+                                  prefix
+                                  (util/entity-type entity))]
+        (purge! storage entity)))
 
     (history [_ entity-id attr]
       (with-tracing [span (format "%s/history %s" prefix attr)]

--- a/src/clj_money/db/datomic.clj
+++ b/src/clj_money/db/datomic.clj
@@ -388,6 +388,52 @@
                  (mapv #(vector :db/retractEntity (:id %))))
             {}))
 
+(def ^:private dependency-attrs
+  {:entity [:commodity/entity
+            :account/entity
+            :transaction/entity
+            :scheduled-transaction/entity
+            :grant/entity
+            :budget/entity]
+   :commodity [:price/commodity
+               :lot/commodity]
+   :account [:reconciliation/account
+             :lot/account] ; probably redundant
+   :lot [:lot-item/lot
+         :lot-note/lots]
+   :transaction [:attachment/transaction]})
+
+(defn- referring-ids
+  "Given an id and an attribute, return all ids that point
+  to the given id via the given attribute"
+  [id attr api]
+  (mapcat identity
+          (query api {:query {:find '[?x]
+                              :in '[$ ?e]
+                              :where [['?x attr '?e]]}
+                      :args [id]})))
+
+(defn- dependent-ids
+  "Given an id and its entity type, return all of the items
+  that reference the given id throughout the dependency graph."
+  [entity-type id api]
+  (mapcat (fn [a]
+            (let [ids (referring-ids id a api)
+                  t (keyword (namespace a))]
+              (->> ids
+                   (mapcat #(dependent-ids t % api))
+                   (concat ids))))
+          (dependency-attrs entity-type)))
+
+(defn- purge*
+  [{:keys [id] :as entity} {:keys [api]}]
+  {:pre [(= :entity (util/entity-type entity))]}
+
+  (let [tx-data (mapcat (juxt #(vector :db/retractEntity %)
+                              #(hash-map :db/excise %))
+                        (distinct (cons id (dependent-ids :entity id api))))]
+    (transact api tx-data {})))
+
 (defmulti init-api ::db/strategy)
 
 (def ^:private history-query
@@ -488,6 +534,7 @@
       (find-many [_ ids]      (find-many* ids {:api api}))
       (select [_ crit opts]   (select* crit opts {:api api}))
       (delete [_ entities]    (delete* entities {:api api}))
+      (purge! [_ entity]      (purge* entity {:api api}))
       (update [_ changes criteria] (update* changes criteria {:api api}))
       (history [_ entity-id attr] (history* entity-id attr {:api api}))
       (close [_])

--- a/src/clj_money/db/sql.clj
+++ b/src/clj_money/db/sql.clj
@@ -484,6 +484,7 @@
       (find-many [this ids] (find-many* ds ids {:storage this}))
       (select [this criteria options] (select* ds criteria (assoc options :storage this)))
       (delete [_ entities] (delete* ds entities))
+      (purge! [_ entity] (delete* ds [entity]))
       (update [_ changes criteria] (update* ds changes criteria))
       (history [_ _entity-id _attr] [])
       (close [_] #_noop)

--- a/src/clj_money/entities.clj
+++ b/src/clj_money/entities.clj
@@ -311,6 +311,11 @@
   {:pre [entity]}
   (delete-many opts [entity]))
 
+(defn purge!
+  [entity]
+  {:pre [entity]}
+  (db/purge! (db/storage) entity))
+
 (defn resolve-ref
   [entity-or-ref]
   {:pre [(map? entity-or-ref)]}

--- a/src/clj_money/entities/budget_items.clj
+++ b/src/clj_money/entities/budget_items.clj
@@ -7,5 +7,5 @@
 (s/def :budget-item/account ::entities/entity-ref)
 (s/def :budget-item/spec (s/nilable ::budgets/item-spec))
 (s/def ::entities/budget-item (s/keys :req [:budget-item/account
-                                          :budget-item/periods]
-                                    :opt [:budget-item/spec]))
+                                            :budget-item/periods]
+                                      :opt [:budget-item/spec]))

--- a/src/clj_money/entities/budgets.clj
+++ b/src/clj_money/entities/budgets.clj
@@ -38,12 +38,12 @@
 (s/def :budget/period ::dates/period)
 (s/def :budget/entity ::entities/entity-ref)
 (s/def ::entities/budget (s/and (s/keys :req [:budget/name
-                                            :budget/start-date
-                                            :budget/period
-                                            :budget/entity]
-                                      :opt [:budget/items])
-                              accounts-belong-to-budget-entity?
-                              period-counts-match?))
+                                              :budget/start-date
+                                              :budget/period
+                                              :budget/entity]
+                                        :opt [:budget/items])
+                                accounts-belong-to-budget-entity?
+                                period-counts-match?))
 
 (defmethod entities/before-save :budget
   [budget]
@@ -57,9 +57,9 @@
          date
          (t/local-date? date)]}
   (entities/find-by #:budget{:start-date [:<= date]
-                           :end-date [:>= date]
-                           :entity entity}
-                  {:include #{:budget/items}}))
+                             :end-date [:>= date]
+                             :entity entity}
+                    {:include #{:budget/items}}))
 
 (defn find-items-by-account
   "Finds items in the specified budget belonging to the specified account or its children."

--- a/src/clj_money/entities/entities.clj
+++ b/src/clj_money/entities/entities.clj
@@ -34,8 +34,8 @@
                                         :settings/default-commodity])))
 
 (s/def ::entities/entity (s/and (s/keys :req [:entity/name
-                                            :entity/user]
-                                      :opt [:entity/settings
-                                            :entity/price-date-range
-                                            :entity/transaction-date-range])
-                              name-is-unique?))
+                                              :entity/user]
+                                        :opt [:entity/settings
+                                              :entity/price-date-range
+                                              :entity/transaction-date-range])
+                                name-is-unique?))

--- a/src/clj_money/repl.clj
+++ b/src/clj_money/repl.clj
@@ -85,6 +85,18 @@
   (atts/propagate-all (entities/find-by {:entity/name entity-name})
                       {}))
 
+(defn purge-entity
+  "Completely and permanently removes the named entity and everything that
+  depends on it. This is irreversible."
+  [{:keys [entity-name user-email]}]
+  (if-let [e (entities/find-by {:entity/name entity-name
+                       :user/email user-email}
+                      {:type :entity})]
+    (entities/purge! e)
+    (println (format "Unable to find an entity named \"%s\" for user \"%s\""
+                     entity-name
+                     user-email))))
+
 (defn parse-performance-logs
   [path]
   (with-open[reader (io/reader path)]

--- a/src/clj_money/tasks.clj
+++ b/src/clj_money/tasks.clj
@@ -249,6 +249,40 @@
       (shutdown-agents)
       (System/exit 0))))
 
+(def ^:private purge-entity-cli-options
+  {:usage "lein purge-entity -- <options>"
+   :description "Completely and permanently remove an entity and everything that depends on it. This is irreversible."
+   :options (conj default-options
+                  ["-u" "--user USER_EMAIL" "The email address of the user that owns the entity to be removed"
+                   :id :user-email
+                   :missing "The user email must be specified"]
+                  ["-e" "--entity ENTITY_NAME" "The name of the entity to be removed"
+                   :id :entity-name
+                   :missing "The entity name must be specified"]
+                  ["-y" "--yes" "Confirm that the entity should be permanently and irreversibly removed"
+                   :id :confirmed?
+                   :missing "Pass -y/--yes to confirm this irreversible operation."])})
+
+(defn purge-entity
+  [& args]
+  (with-options [parsed (assoc purge-entity-cli-options
+                               :args args)]
+    (let [{{:keys [user-email
+                   entity-name]} :options} parsed
+          user (entities/find-by {:user/email user-email})
+          _ (assert user
+                    (format "Unable to find user with email address \"%s\"."
+                            user-email))
+          entity (entities/find-by {:entity/user user
+                                    :entity/name entity-name})]
+      (assert entity
+              (format "Unable to find an entity named \"%s\"."
+                      entity-name))
+      (entities/purge! entity)
+      (println "Purged entity" entity-name)
+      (shutdown-agents)
+      (System/exit 0))))
+
 (defn- er-entity
   [{:keys [id fields]}]
   (concat

--- a/test/clj_money/entities/entities_test.clj
+++ b/test/clj_money/entities/entities_test.clj
@@ -1,18 +1,31 @@
 (ns clj-money.entities.entities-test
   (:require [clojure.test :refer [is testing]]
             [clojure.pprint :refer [pprint]]
+            [clojure.java.io :as io]
             [java-time.api :as t]
             [dgknght.app-lib.test-assertions]
             [clj-money.entities.ref]
             [clj-money.db.ref]
             [clj-money.test-context :refer [with-context
+                                            basic-context
                                             find-user
                                             find-account
-                                            find-entity]]
+                                            find-commodity
+                                            find-entity
+                                            find-image
+                                            find-price
+                                            find-attachment
+                                            find-budget-item
+                                            find-scheduled-transaction
+                                            find-grant
+                                            find-lot
+                                            find-lot-note
+                                            find-reconciliation]]
             [clj-factory.core :refer [factory]]
             [clj-money.entity-helpers :as helpers :refer [assert-invalid
                                                          assert-updated
                                                          assert-deleted]]
+            [clj-money.images.sql]
             [clj-money.util :as util]
             [clj-money.entities :as entities]
             [clj-money.factories.user-factory]
@@ -114,3 +127,122 @@
                     {:entity/settings
                      {:settings/inventory-method
                       ["Inventory method must be fifo or lifo"]}})))
+
+(def ^:private purge-context
+  (conj basic-context
+        #:commodity{:entity "Personal"
+                    :type :stock
+                    :name "Apple, Inc."
+                    :symbol "AAPL"
+                    :exchange :nasdaq}
+        #:price{:commodity "AAPL"
+                :trade-date (t/local-date 2017 3 2)
+                :value 12.34M}
+        #:transaction{:transaction-date (t/local-date 2017 1 1)
+                      :entity "Personal"
+                      :description "Paycheck"
+                      :debit-account "Checking"
+                      :credit-account "Salary"
+                      :quantity 1000M}
+        #:image{:user "john@doe.com"
+                :original-filename "receipt.jpg"
+                :content-type "image/jpg"
+                :content (io/file (io/resource "fixtures/attachment.jpg"))}
+        #:attachment{:caption "Receipt"
+                     :transaction [(t/local-date 2017 1 1) "Paycheck"]
+                     :image "receipt.jpg"}
+        #:budget{:name "2017"
+                 :entity "Personal"
+                 :start-date (t/local-date 2017 1 1)
+                 :period [1 :month]
+                 :items [#:budget-item{:account "Groceries"
+                                       :periods (repeat 1 50M)}]}
+        #:scheduled-transaction{:entity "Personal"
+                                :description "Scheduled Paycheck"
+                                :start-date (t/local-date 2017 1 1)
+                                :date-spec {:day 1}
+                                :period [1 :month]
+                                :items [#:scheduled-transaction-item{:action :debit
+                                                                     :account "Checking"
+                                                                     :quantity 900M}
+                                        #:scheduled-transaction-item{:action :credit
+                                                                     :account "Salary"
+                                                                     :quantity 900M}]}
+        #:reconciliation{:account "Checking"
+                         :end-of-period (t/local-date 2017 1 31)
+                         :balance 1000M
+                         :status :new
+                         :items [[(t/local-date 2017 1 1) 1000M]]}
+        #:grant{:entity "Personal"
+                :user "jane@doe.com"
+                :permissions {:account #{:index :show}}}
+        #:lot{:account "Checking"
+              :commodity "AAPL"
+              :purchase-price 12.34M
+              :shares-purchased 10M
+              :shares-owned 10M
+              :purchase-date (t/local-date 2017 3 2)}
+        #:lot-note{:lots [["Checking" "AAPL" (t/local-date 2017 3 2)]]
+                   :transaction-date (t/local-date 2017 3 2)
+                   :memo "Note"}
+        #:trade{:entity "Personal"
+                :date (t/local-date 2017 4 1)
+                :type :purchase
+                :account "Checking" ; We wouldn't really by a stock from checking
+                :commodity "AAPL"
+                :shares 5M
+                :value 500M}))
+
+(dbtest purge-an-entity
+  (with-context purge-context
+    (let [entity (find-entity "Personal")
+          image (find-image "receipt.jpg")
+          business (find-entity "Business")
+          scheduled-transaction (find-scheduled-transaction "Scheduled Paycheck")
+          grant (find-grant ["Personal" "jane@doe.com"])
+          lot (find-lot ["Checking" "AAPL" (t/local-date 2017 3 2)])
+          lot-note (find-lot-note [(t/local-date 2017 3 2) "Note"])
+          trade-lot (entities/find-by
+                      #:lot{:account (util/->entity-ref (find-account "Checking"))
+                            :commodity (util/->entity-ref (find-commodity "AAPL"))
+                            :purchase-date (t/local-date 2017 4 1)})]
+      (entities/purge! entity)
+
+      (is (nil? (entities/find entity))
+          "The entity itself is removed")
+      (is (empty? (entities/select {:account/entity entity}))
+          "The entity's accounts are removed")
+      (is (empty? (entities/select {:commodity/entity entity}))
+          "The entity's commodities are removed")
+      (is (nil? (entities/find (find-price ["AAPL" (t/local-date 2017 3 2)])))
+          "Prices for the entity's commodities are removed")
+      (is (empty? (entities/select {:transaction/entity entity}))
+          "The entity's transactions are removed")
+      (is (nil? (entities/find (find-attachment "Receipt")))
+          "Attachments on the entity's transactions are removed")
+      (is (empty? (entities/select {:budget/entity entity}))
+          "The entity's budgets are removed")
+      (is (nil? (entities/find (find-budget-item ["2017" "Groceries"])))
+          "The entity's budget items are removed")
+      (is (nil? (entities/find scheduled-transaction))
+          "The entity's scheduled transactions are removed")
+      (is (nil? (entities/find (find-reconciliation ["Checking" (t/local-date 2017 1 31)])))
+          "The entity's reconciliations are removed")
+      (is (nil? (entities/find grant))
+          "The entity's grants are removed")
+      (is (nil? (entities/find lot))
+          "The entity's lots are removed")
+      (is (nil? (entities/find lot-note))
+          "The entity's lot notes are removed")
+      (is (nil? (entities/find trade-lot))
+          "The lot created by a trade is removed")
+
+      (is (some? (entities/find image))
+          "A shared, user-owned image is not removed along with an attachment")
+
+      (is (some? (entities/find business))
+          "An unrelated entity belonging to the same user is not removed")
+      (is (seq (entities/select {:account/entity business}))
+          "An unrelated entity's accounts are not removed")
+      (is (seq (entities/select {:commodity/entity business}))
+          "An unrelated entity's commodities are not removed"))))


### PR DESCRIPTION
## Summary
- Add `purge!` to the `Storage` protocol so an entity and everything that depends on it can be permanently and irreversibly removed.
- SQL implementation delegates to a normal `delete` and relies on cascading DB behavior; two new migrations add `ON DELETE CASCADE` for `transaction_item`→`account` and a trigger to clean up orphaned `lot_note` rows (an array-based relationship that can't be expressed as an FK).
- Datomic implementation walks a hand-maintained dependency graph (`dependency-attrs`) and retracts/excises every transitively dependent id.
- Exposed via `clj-money.entities/purge!`, a `repl.clj` helper, and a new `lein purge-entity` CLI task (`-u/--user`, `-e/--entity`, `-y/--yes`).
- Adds a `purge-context` test fixture covering commodities, prices, transactions, images, attachments, budgets, scheduled transactions, reconciliations, grants, lots, lot-notes, and trades, verifying cascading removal while confirming an unrelated entity and a shared image are untouched.

## Test plan
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [x] `lein test` — all non-database tests pass; `*-sql` dbtests error only on `UnknownHostException: sql` (no Postgres reachable in this sandbox, not a code issue); no Datomic strategy is configured locally either, so the new `purge-an-entity` dbtest could not be exercised here
- [ ] Run `lein purge-entity -u <email> -e <entity> -y` (or the equivalent REPL/`entities/purge!` call) against a disposable entity on both SQL and Datomic backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb