### PR TITLE
Accept Trello card JSON from a file arg, unwrap MCP text payloads

### DIFF
--- a/.claude/scripts/parse_trello_cards.py
+++ b/.claude/scripts/parse_trello_cards.py
@@ -1,11 +1,24 @@
 import json, sys
 
-data = json.load(sys.stdin)
-cards = json.loads(data[0]['text'])
-sorted_cards = sorted(cards, key=lambda c: c['pos'])
-top5 = sorted_cards[:5]
-for c in top5:
-    labels = [l['name'] for l in c.get('labels', [])]
-    print(f"pos={c['pos']:.0f} | {c['name']} | labels={labels}")
-    print(f"  desc: {c['desc'][:200]}")
-    print()
+
+def load_cards(raw):
+    data = json.loads(raw)
+    # MCP tool results are sometimes wrapped as [{"text": "<json array>"}]
+    if isinstance(data, list) and data and isinstance(data[0], dict) and "text" in data[0]:
+        return json.loads(data[0]["text"])
+    return data
+
+
+def main():
+    raw = open(sys.argv[1]).read() if len(sys.argv) > 1 else sys.stdin.read()
+    cards = load_cards(raw)
+    sorted_cards = sorted(cards, key=lambda c: c["pos"])
+    for c in sorted_cards[:5]:
+        labels = [l["name"] for l in c.get("labels", [])]
+        print(f"pos={c['pos']:.0f} | {c['name']} | labels={labels}")
+        print(f"  desc: {c['desc'][:200]}")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `parse_trello_cards.py` now accepts an optional file-path argument in addition to reading from stdin.
- MCP tool results are sometimes wrapped as `[{"text": "<json array>"}]` rather than a bare array; the script now unwraps that shape before parsing so it works with both raw exports and MCP output saved to a file.

## Test plan
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings (unaffected, but confirms the repo still lints clean)
- [ ] Run the script against both a raw Trello export and an MCP-wrapped payload to confirm both paths parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb