### PR TITLE
Add UI action to recalculate an account's balance and indexes

### DIFF
--- a/src/clj_money/api/accounts.clj
+++ b/src/clj_money/api/accounts.clj
@@ -7,6 +7,7 @@
             [dgknght.app-lib.api :as api]
             [clj-money.util :as util]
             [clj-money.entities :as entities]
+            [clj-money.entities.transactions :as transactions]
             [clj-money.authorization :as auth :refer [authorize
                                                       +scope]]
             [clj-money.authorization.accounts]))
@@ -107,9 +108,18 @@
       (api/response))
     api/not-found))
 
+(defn- recalculate
+  [req]
+  (if-let [account (find-and-auth req ::auth/recalculate)]
+    (let [entity (entities/find (:account/entity account))]
+      (transactions/propagate-account-from-start entity account)
+      (api/response (entities/find account)))
+    api/not-found))
+
 (def routes
   [["entities/:entity-id/accounts" {:get {:handler index}
                                     :post {:handler create}}]
    ["accounts/:id" {:get {:handler show}
                     :patch {:handler update}
-                    :delete {:handler delete}}]])
+                    :delete {:handler delete}}]
+   ["accounts/:id/recalculate" {:post {:handler recalculate}}]])

--- a/src/clj_money/api/accounts.cljs
+++ b/src/clj_money/api/accounts.cljs
@@ -42,3 +42,11 @@
               (add-error-handler
                 opts
                 "Unable to delete the account: %s")))
+
+(defn recalculate
+  [account & {:as opts}]
+  (api/post (api/path :accounts account :recalculate)
+            {}
+            (add-error-handler
+              opts
+              "Unable to recalculate the account: %s")))

--- a/src/clj_money/authorization.clj
+++ b/src/clj_money/authorization.clj
@@ -6,6 +6,7 @@
 (derive ::show ::manage)
 (derive ::update ::manage)
 (derive ::destroy ::manage)
+(derive ::recalculate ::manage)
 
 (defmulti allowed?
   "Returns a truthy or falsey value indicating whether or not the

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -68,6 +68,13 @@
                      :callback -busy
                      :on-success fetch-accounts)))
 
+(defn- recalculate
+  [account]
+  (+busy)
+  (accounts/recalculate account
+                        :callback -busy
+                        :on-success fetch-accounts))
+
 (defn- toggle-account
   [id page-state]
   (swap! page-state update-in [:expanded] (fn [expanded]
@@ -202,6 +209,10 @@
               :pie-chart-fill
               :pie-chart)
             :size :small)]
+     [:button.btn.btn-secondary.btn-sm
+      {:on-click #(recalculate account)
+       :title "Click here to recalculate the balance and transaction indexes for this account."}
+      (icon :arrow-clockwise :size :small)]
      [:button.btn.btn-danger.btn-sm
       {:on-click #(delete account)
        :title "Click here to remove this account."}

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -69,11 +69,22 @@
                      :on-success fetch-accounts)))
 
 (defn- recalculate
-  [account]
+  [account page-state]
   (+busy)
+  (swap! page-state update-in [:recalculating] conj (:id account))
   (accounts/recalculate account
-                        :callback -busy
-                        :on-success fetch-accounts))
+                        :callback (comp -busy
+                                        #(swap! page-state
+                                                update-in
+                                                [:recalculating]
+                                                disj
+                                                (:id account)))
+                        :on-success (fn [& _]
+                                      (notify/toast "Reindexing Finished"
+                                                    (str "The account \""
+                                                         (:account/name account)
+                                                         "\" has finished."))
+                                      (fetch-accounts))))
 
 (defn- toggle-account
   [id page-state]
@@ -185,38 +196,41 @@
 (defn- account-row-buttons
   [account page-state]
   (fn []
-    [:div.btn-group
-     [:button.btn.btn-secondary.btn-sm
-      {:on-click (select-account account page-state)
-       :title "Click here to view transactions for this account."}
-      (icon :collection :size :small)]
-     [:button.btn.btn-secondary.btn-sm
-      {:on-click (fn []
-                   (swap! page-state assoc :selected account)
-                   (set-focus "parent-id"))
-       :title "Click here to edit this account."}
-      (icon :pencil :size :small)]
-     [:button.btn.btn-secondary
-      {:on-click #(swap! page-state
-                         assoc
-                         :allocation
-                         {:account (prepare-for-allocation account)
-                          :cash (:account/value account)
-                          :withdrawal 0M})
-       :disabled (not (system-tagged? account :trading))
-       :title "Click here to manage asset allocation for this account."}
-      (icon (if (system-tagged? account :trading)
-              :pie-chart-fill
-              :pie-chart)
-            :size :small)]
-     [:button.btn.btn-secondary.btn-sm
-      {:on-click #(recalculate account)
-       :title "Click here to recalculate the balance and transaction indexes for this account."}
-      (icon :arrow-clockwise :size :small)]
-     [:button.btn.btn-danger.btn-sm
-      {:on-click #(delete account)
-       :title "Click here to remove this account."}
-      (icon :x-circle :size :small)]]))
+    (let [recalculating (r/cursor page-state [:recalculating])]
+      [:div.btn-group
+       [:button.btn.btn-secondary.btn-sm
+        {:on-click (select-account account page-state)
+         :title "Click here to view transactions for this account."}
+        (icon :collection :size :small)]
+       [:button.btn.btn-secondary.btn-sm
+        {:on-click (fn []
+                     (swap! page-state assoc :selected account)
+                     (set-focus "parent-id"))
+         :title "Click here to edit this account."}
+        (icon :pencil :size :small)]
+       [:button.btn.btn-secondary
+        {:on-click #(swap! page-state
+                           assoc
+                           :allocation
+                           {:account (prepare-for-allocation account)
+                            :cash (:account/value account)
+                            :withdrawal 0M})
+         :disabled (not (system-tagged? account :trading))
+         :title "Click here to manage asset allocation for this account."}
+        (icon (if (system-tagged? account :trading)
+                :pie-chart-fill
+                :pie-chart)
+              :size :small)]
+       [:button.btn.btn-secondary.btn-sm
+        {:on-click #(recalculate account page-state)
+         :title "Click here to recalculate the balance and transaction indexes for this account."}
+        (if (@recalculating (:id account))
+          [:div.spinner-border.spinner-border-sm {:role :state}]
+          (icon :arrow-clockwise :size :small))]
+       [:button.btn.btn-danger.btn-sm
+        {:on-click #(delete account)
+         :title "Click here to remove this account."}
+        (icon :x-circle :size :small)]])))
 
 (defn- account-row
   [{:keys [id] :account/keys [parent-ids] :as account} expanded page-state]
@@ -1171,6 +1185,7 @@
   (let [page-state (r/atom {:expanded #{}
                             :hide-zero-balances? (any-non-zero-balances?)
                             :filter-tags #{}
+                            :recalculating #{}
                             :ctl-chan (chan)})
         default-commodity (make-reaction
                             #(get-in @current-entity

--- a/test/clj_money/api/accounts_test.clj
+++ b/test/clj_money/api/accounts_test.clj
@@ -305,3 +305,33 @@
 
 (deftest a-user-cannot-delete-an-account-in-anothers-entity
   (assert-blocked-delete (delete-an-account "jane@doe.com")))
+
+(defn- recalculate-an-account
+  [email]
+  (with-context
+    (let [account (find-account "Checking")
+          response (-> (request :post (path :api
+                                            :accounts
+                                            (:id account)
+                                            :recalculate)
+                                :user (find-user email))
+                       app
+                       parse-body)]
+      [response account])))
+
+(defn- assert-successful-recalculate
+  [[response account]]
+  (is (http-success? response))
+  (is (comparable? {:account/name (:account/name account)}
+                   (:parsed-body response))
+      "The recalculated account is returned in the response"))
+
+(defn- assert-blocked-recalculate
+  [[response _account]]
+  (is (http-not-found? response)))
+
+(deftest a-user-can-recalculate-an-account-in-his-entity
+  (assert-successful-recalculate (recalculate-an-account "john@doe.com")))
+
+(deftest a-user-cannot-recalculate-an-account-in-anothers-entity
+  (assert-blocked-recalculate (recalculate-an-account "jane@doe.com")))


### PR DESCRIPTION
## Summary
- Adds `POST /api/accounts/:id/recalculate`, which finds and authorizes the account then invokes the existing `clj-money.entities.transactions/propagate-account-from-start` (previously only reachable via `lein re-index`) to recompute `:transaction-item/index`/`:transaction-item/balance` for all of the account's items and the account's own balance.
- Adds a `::recalculate` authorization action (derived from `::manage`, same as the other account actions) and the corresponding `accounts/recalculate` client function.
- Adds a recalculate button (⟳) next to each account row in the accounts view.

Closes Trello card #284 (Recalculate an account balance).

## Test plan
- [x] `lein test clj-money.api.accounts-test` — 14 tests, 0 failures/errors, including new `a-user-can-recalculate-an-account-in-his-entity` / `a-user-cannot-recalculate-an-account-in-anothers-entity`
- [x] `lein test` (full suite) — 0 failures; the 248 errors present are pre-existing `-sql` variant tests failing due to no local Postgres in this sandbox, unrelated to this change
- [x] `lein fig:test` (client tests) — 105 tests, 0 failures/errors; confirms cljs changes compile
- [x] `clj-kondo --lint src:test` — 0 errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAT1PYLUfxJV93SgKa2fb