### PR TITLE
Fix account-wide reindex when realizing a scheduled transaction

### DIFF
--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -367,7 +367,8 @@
                      {:transaction-item/account account
                       :transaction/transaction-date [:>= as-of]}
                      :transaction-item)
-                   {:sort [[:transaction-item/index :asc]]
+                   {:sort [:transaction/transaction-date
+                           :transaction-item/index]
                     :select-also [:transaction/transaction-date]}))
 
 (defn- propagate-transaction-items
@@ -694,8 +695,7 @@
                            :basis (or (last-transaction-item-before account date)
                                       initial-basis)
                            :items (map #(assoc % :transaction-item/account account)
-                                       (entities/select {:transaction-item/account account}
-                                                        {:select-also [:transaction/transaction-date]}))})
+                                       (transaction-items-on-or-after account date))})
                         #(assoc-in % [0 :account/entity] entity)
                         #(update-in % [0 :account/commodity] (comp commodities :id))
                         #(update-in % [0] accounts)))

--- a/test/clj_money/api/scheduled_transactions_test.clj
+++ b/test/clj_money/api/scheduled_transactions_test.clj
@@ -363,7 +363,15 @@
       "The transaction is created with the next projected transaction date")
   (is (comparable? #:scheduled-transaction{:last-occurrence (t/local-date 2016 2 1)}
                    (entities/find (find-scheduled-transaction "Paycheck")))
-      "The scheduled trx record is updated with the last occurrence"))
+      "The scheduled trx record is updated with the last occurrence")
+  (is (= [#:transaction-item{:index 0 :quantity 50M :balance -50M}
+          #:transaction-item{:index 1 :quantity 1000M :balance 950M}]
+         (->> (entities/select {:transaction-item/account (find-account "Checking")}
+                               {:sort [:transaction-item/index]})
+              (map #(select-keys % [:transaction-item/index
+                                    :transaction-item/quantity
+                                    :transaction-item/balance]))))
+      "The pre-existing item keeps its index/balance and the new item is appended without reprocessing account history"))
 
 (defn- assert-blocked-realization
   [response]

--- a/test/clj_money/entities/transactions_test.clj
+++ b/test/clj_money/entities/transactions_test.clj
@@ -913,6 +913,44 @@
                        (entities/find entity))
           "The entity transaction date boundaries are updated"))))
 
+(def ^:private delayed-propagation-with-history-context
+  (conj base-context
+        #:transaction{:transaction-date (t/local-date 2016 12 1)
+                      :entity "Personal"
+                      :description "Paycheck"
+                      :debit-account "Checking"
+                      :credit-account "Salary"
+                      :quantity 500M}))
+
+(dbtest create-multiple-transactions-then-recalculate-balances-with-existing-history
+  (with-context delayed-propagation-with-history-context
+    (let [entity (find-entity "Personal")
+          [checking
+           salary] (find-accounts "Checking" "Salary")]
+      (transactions/with-delayed-propagation [out-chan ctrl-chan]
+        (mapv (comp #(entities/put %
+                                   :out-chan out-chan
+                                   :close-chan? false
+                                   :ctrl-chan ctrl-chan)
+                    #(assoc % :transaction/entity entity))
+              [#:transaction{:transaction-date (t/local-date 2017 1 1)
+                             :description "Paycheck"
+                             :debit-account checking
+                             :credit-account salary
+                             :quantity 1000M}
+               #:transaction{:transaction-date (t/local-date 2017 2 1)
+                             :description "Paycheck"
+                             :debit-account checking
+                             :credit-account salary
+                             :quantity 1000M}]))
+      (is (= [#:transaction-item{:index 0 :quantity 500M :balance 500M}
+              #:transaction-item{:index 1 :quantity 1000M :balance 1500M}
+              #:transaction-item{:index 2 :quantity 1000M :balance 2500M}]
+             (items-by-account "Checking"))
+          "The pre-existing item keeps its index and balance and the new items are appended sequentially, without reprocessing existing history")
+      (is (= 2500M (:account/quantity (reload-account "Checking")))
+          "The account balance reflects the pre-existing item plus the new items exactly once"))))
+
 (def ^:private existing-reconciliation-context
   (conj (mapv (fn [entity]
                 (cond-> entity


### PR DESCRIPTION
## Summary
- Fixes Trello card #285: realizing a scheduled transaction was reindexing/overstating balances for an account's entire transaction history instead of just the newly created items.
- Root cause: `propagate-accounts` (the batch reindex path used only by scheduled-transaction realize/mass-realize) fetched an account's items with no date filter and no sort, then re-indexed that whole unsorted set from a basis item that was itself included in the set — double-counting existing items and inflating indices/balances.
- Fix reuses the already-correct `transaction-items-on-or-after` query (the same one the normal per-transaction propagation path uses), limiting the batch reindex to items on/after the affected date. Also updated its sort to `[transaction-date, index]` since freshly-realized items don't have a meaningful index yet.

## Test plan
- [x] `lein test clj-money.entities.transactions-test` — added a new unit test (`create-multiple-transactions-then-recalculate-balances-with-existing-history`) that reproduces the bug via `with-delayed-propagation` against an account with pre-existing history; confirmed it fails without the fix and passes with it.
- [x] `lein test clj-money.api.scheduled-transactions-test` — added index/balance assertions to the existing `realize-context` scenario (which already had pre-existing account history).
- [x] `lein test` — full suite, 919 tests, 0 failures.
- [x] `lein cloverage` — full suite, no threshold failures; touched namespaces at healthy coverage (entities.transactions 89.4%/91.7%, scheduled-transactions 99.2%/100%).
- [x] `clj-kondo --lint src:test` — clean.

https://claude.ai/code/session_01MfB8481AGSeviMJ3mo7VhV