### PR TITLE
Fix print-view report headers reading dates from the wrong state path

### DIFF
--- a/src/clj_money/views/reports.cljs
+++ b/src/clj_money/views/reports.cljs
@@ -165,8 +165,8 @@
   [page-state]
   (let [selected (r/cursor page-state [:selected])
         hide? (make-reaction #(not= :income-statement @selected))
-        start-date (r/cursor page-state [:income-statement :start-date])
-        end-date (r/cursor page-state [:income-statement :end-date])]
+        start-date (r/cursor page-state [:income-statement :options :start-date])
+        end-date (r/cursor page-state [:income-statement :options :end-date])]
     (fn []
       [:span {:class (when @hide? "d-none")}
        (format-date @start-date)
@@ -273,7 +273,7 @@
   [page-state]
   (let [selected (r/cursor page-state [:selected])
         hide? (make-reaction #(not= :balance-sheet @selected))
-        as-of (r/cursor page-state [:balance-sheet :as-of])]
+        as-of (r/cursor page-state [:balance-sheet :options :as-of])]
     (fn []
       [:span {:class (when @hide? "d-none")}
        (format-date @as-of)])))
@@ -670,6 +670,15 @@
                                           [:by-account :by-commodity]))
        [forms/date-field options [:filter :as-of]]])))
 
+(defn- portfolio-header
+  [page-state]
+  (let [selected (r/cursor page-state [:selected])
+        hide? (make-reaction #(not= :portfolio @selected))
+        as-of (r/cursor page-state [:portfolio :options :filter :as-of])]
+    (fn []
+      [:span {:class (when @hide? "d-none")}
+       (format-date @as-of)])))
+
 (defn- portfolio
   [page-state]
   (let [selected (r/cursor page-state [:selected])
@@ -792,7 +801,8 @@
         [:h2
          [income-statement-header page-state]
          [balance-sheet-header page-state]
-         [budget-header page-state]]]
+         [budget-header page-state]
+         [portfolio-header page-state]]]
        [:div.d-print-none
         [filter-elem page-state]
         [small-nav page-state]


### PR DESCRIPTION
## Summary
- Trello #290: the printable income statement (and balance sheet) showed empty spaces where the start/end dates should be
- Root cause: `income-statement-header` and `balance-sheet-header` in `reports.cljs` read their date cursors one level too shallow (e.g. `[:income-statement :start-date]` instead of `[:income-statement :options :start-date]`), so the cursor always resolved to `nil` and `format-date` rendered an empty string
- Also added a missing print header for the portfolio report's as-of date, since the card asked that all reports be checked for correct print-view rendering

## Test plan
- [x] `clj-kondo --lint src/clj_money/views/reports.cljs` — 0 errors, 0 warnings
- [x] `lein fig:build` compiles cleanly
- [x] Manually verified in the browser (logged into the dev app) that the print-view header spans now render the correct dates for Balance Sheet, Income Statement, and Portfolio tabs (previously empty for the first two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)