### PR TITLE
Wire up the budget report gear button to edit budget amounts

### DIFF
--- a/src/clj_money/views/budgets.cljs
+++ b/src/clj_money/views/budgets.cljs
@@ -645,8 +645,12 @@
 (defn- index []
   (let [page-state (r/atom {})
         selected (r/cursor page-state [:selected])
-        detailed-budget (r/cursor page-state [:detailed-budget])]
+        detailed-budget (r/cursor page-state [:detailed-budget])
+        edit-budget-id (:edit-budget-id @app-state)]
     (load-budgets page-state)
+    (when edit-budget-id
+      (swap! app-state dissoc :edit-budget-id)
+      (load-budget-details {:id edit-budget-id} page-state))
     (add-watch current-entity ::index (fn [& _] (load-budgets page-state)))
     (fn []
       [:div.mt-3

--- a/src/clj_money/views/reports.cljs
+++ b/src/clj_money/views/reports.cljs
@@ -335,7 +335,14 @@
          [forms/select-field options [:budget-id] budget-items]
          [forms/integer-field options [:depth] {:class "ms-sm-2"
                                                 :placeholder "Depth"
-                                                :style {:width "5em"}}]]))))
+                                                :style {:width "5em"}}]
+         [:div.mt-3
+          [:a.btn.btn-outline-secondary
+           {:href "/budgets"
+            :data-bs-dismiss :offcanvas
+            :on-click #(swap! app-state assoc :edit-budget-id (:budget-id @options))
+            :title "Click here to edit the amounts for this budget."}
+           (icon-with-text :pencil "Edit Amounts")]]]))))
 
 (defn- receive-budget
   [budget


### PR DESCRIPTION
## Summary
- The gear button on the Budget report tab only opened the report's filter options (budget picker, depth) — clicking it never let the user edit the budget's amounts, as the button implied it should (Trello #293).
- Add an "Edit Amounts" action to that options panel that navigates to the Budgets page and opens the selected budget's detail editor directly, reusing the existing budget-items editor.

## Test plan
- [x] Manually verified in the browser: opened Reports → Budget, clicked the gear button, clicked "Edit Amounts", confirmed it navigates to `/budgets` and opens the selected budget's amount editor.
- [x] Confirmed the flag used to trigger this (`:edit-budget-id`) doesn't linger — navigating to `/budgets` normally afterward shows the plain budget list.
- [x] `clj-kondo --lint` clean on both modified files.
- [x] No backend/Clojure files touched, so `lein test` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bi3PZRmhj64q1cgVR9ZaAP