### PR TITLE
Fix budget report depth control

### DIFF
--- a/src/clj_money/views/reports.cljs
+++ b/src/clj_money/views/reports.cljs
@@ -81,6 +81,10 @@
          inc)
     9))
 
+(defn- budget-max-depth
+  [report]
+  (report-max-depth (mapcat :report/items (:items report))))
+
 (defmulti load-report #(:selected (deref %)))
 
 (defmethod load-report :income-statement
@@ -306,10 +310,12 @@
 (defn- receive-budget-report
   [page-state]
   (fn [report]
-    (swap! page-state
-           #(-> %
-                (assoc-in [:budget :report] report)
-                (update-in [:budget] dissoc :apply-info)))))
+    (let [max-d (budget-max-depth report)]
+      (swap! page-state
+             #(-> %
+                  (assoc-in [:budget :report] report)
+                  (assoc-in [:budget :options :depth] (dec max-d))
+                  (update-in [:budget] dissoc :apply-info))))))
 
 (defmethod load-report :budget
   [page-state]
@@ -329,15 +335,33 @@
         budgets (r/cursor page-state [:budgets])
         budget-items (make-reaction #(->> (vals @budgets)
                                           (sort-by :budget/start-date t/after?)
-                                          (map (juxt :id :budget/name))))]
+                                          (map (juxt :id :budget/name))))
+        report (r/cursor page-state [:budget :report])
+        depth (r/cursor options [:depth])
+        max-depth (make-reaction #(budget-max-depth @report))]
     (fn []
       (when (and (= :budget @selected)
                  (seq @budget-items))
         [:<>
          [forms/select-field options [:budget-id] budget-items]
-         [forms/integer-field options [:depth] {:class "ms-sm-2"
-                                                :placeholder "Depth"
-                                                :style {:width "5em"}}]]))))
+         [:label.form-label.mt-2
+          {:for "budget-depth"}
+          "Depth"]
+         [:input#budget-depth.form-range
+          {:type :range
+           :min 1
+           :max @max-depth
+           :step 1
+           :value (or (some-> @depth inc) @max-depth)
+           :list "budget-depth-markers"
+           :on-change (fn [e]
+                        (let [v (dom/value (dom/target e))]
+                          (swap! options assoc :depth (dec (parse-long v)))))}]
+         [:div.d-flex.justify-content-between.px-1
+          {:style {:margin-top "-10px"}}
+          (for [x (range @max-depth)]
+            ^{:key (str "budget-depth-" x)}
+            [:span.border-start {:style {:height "10px"}}])]]))))
 
 (defn- receive-budget
   [{account-id :id
@@ -415,7 +439,9 @@
 (defn- refine-items
   [depth items]
   (->> items
-       (remove #(< depth (:report/depth %)))
+       (remove #(> (:report/depth %) depth))
+       (remove #(and (< (:report/depth %) depth)
+                     (:report/roll-up %)))
        (map #(if (= depth (:report/depth %))
                (merge % (:report/roll-up %))
                %))
@@ -749,7 +775,7 @@
            :balance-sheet {:options {:as-of (t/today)
                                      :hide-zeros? true
                                      :depth nil}}
-           :budget {:options {:depth 1
+           :budget {:options {:depth 0
                               :tags [:tax :mandatory :discretionary]}} ; TODO: make this user editable
            :portfolio {:options {:filter {:aggregate :by-account
                                           :as-of (t/today)}


### PR DESCRIPTION
## Summary
- Replace the numeric depth text input on the Budget report with a range slider, matching the Balance Sheet and Income Statement reports.
- Fix `refine-items` so changing the depth actually changes the rendered report — previously it only removed rows *deeper* than the selected depth, leaving shallower parent rows in place regardless of the setting.
- At a given depth, show only the accounts at that depth, using aggregated roll-up totals for accounts with children, instead of showing parent and child rows together. Leaf accounts that don't reach the selected depth are still shown (using their own values) so data isn't silently dropped.

Closes Trello card #292 (Adjust budget report depth).

## Test plan
- [x] `clj-kondo --lint src/clj_money/views/reports.cljs` — clean
- [x] `lein fig:test` — 106 tests, 370 assertions, 0 failures
- [ ] Manual verification in a browser against a budget with a multi-level account hierarchy (not possible in this sandbox — no local Postgres available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bi3PZRmhj64q1cgVR9ZaAP