### PR TITLE
Fix transaction edit crash when looking up by transaction-item id

### DIFF
--- a/src/clj_money/api/transactions.clj
+++ b/src/clj_money/api/transactions.clj
@@ -30,7 +30,8 @@
 (defn- throw-on-missing-constraint
   [criteria]
   (when-not ((some-fn :transaction/transaction-date
-                      :transaction/created-at)
+                      :transaction/created-at
+                      :transaction-item/_self)
              criteria)
     (throw (ex-info "Invalid criteria" {:criteria criteria})))
   criteria)
@@ -45,7 +46,7 @@
                     :transaction-item-id :transaction-item/_self
                     :created-at :transaction/created-at
                     :entity-id :transaction/entity})
-      (update-in [:transaction/entity] #(hash-map :id %))
+      (update-in-if [:transaction/entity] #(hash-map :id %))
       (update-in-if [:transaction-item/_self] #(hash-map :id %))
       (select-keys [:transaction/entity
                     :transaction/transaction-date

--- a/test/clj_money/api/transactions_test.clj
+++ b/test/clj_money/api/transactions_test.clj
@@ -20,7 +20,8 @@
                                             find-user
                                             find-entity
                                             find-account
-                                            find-transaction]]
+                                            find-transaction
+                                            find-transaction-item]]
             [clj-money.test-helpers :refer [reset-db]]
             [clj-money.web.server :refer [app]]))
 
@@ -117,6 +118,23 @@
 (deftest a-user-cannot-get-transactions-in-anothers-entity
   (with-context existing-context
     (assert-blocked-list (get-a-list "jane@doe.com"))))
+
+(defn- get-a-list-by-item
+  [email]
+  (let [item (find-transaction-item [(t/local-date 2016 2 1) 1000M "Checking"])]
+    (-> (request :get (+query (path :api :transactions)
+                              {:transaction-item-id (:id item)})
+                 :user (find-user email))
+        app
+        parse-body)))
+
+(deftest a-user-can-get-a-transaction-by-item-id
+  (with-context existing-context
+    (assert-successful-list (get-a-list-by-item "john@doe.com"))))
+
+(deftest a-user-cannot-get-a-transaction-by-item-id-in-anothers-entity
+  (with-context existing-context
+    (assert-blocked-list (get-a-list-by-item "jane@doe.com"))))
 
 (defn- get-a-transaction
   [email & {:keys [content-type]


### PR DESCRIPTION
## Summary
- Clicking the pencil icon on a transaction row (Accounts screen) threw a server error: `Invalid criteria {:criteria {:transaction/entity {:id nil}, :transaction-item/_self {:id ...}}}`.
- `throw-on-missing-constraint` required a `transaction-date` or `created-at` on every query, but the edit flow looks up the transaction solely by `transaction-item-id`. Relaxed the constraint to also accept `:transaction-item/_self`.
- Separately, `:transaction/entity` was folded into the criteria unconditionally (`update-in` instead of `update-in-if`), injecting `{:transaction/entity {:id nil}}` whenever no `entity-id` was supplied — this would have silently hidden the results even after fixing the crash. Changed to `update-in-if`.

## Test plan
- [x] Added `a-user-can-get-a-transaction-by-item-id` and `a-user-cannot-get-a-transaction-by-item-id-in-anothers-entity` to `test/clj_money/api/transactions_test.clj`
- [x] `lein test clj-money.api.transactions-test` — 15 tests, 42 assertions, 0 failures
- [x] `lein test` (full suite) — 931 tests, 2444 assertions, 0 failures
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [x] `lein cloverage` — `clj-money.api.transactions` at 97.12% line / 98.11% form coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KoXoVR9YUgNowLcrL6o71