### PR TITLE
Remember the last active entity across sessions

### DIFF
--- a/src/clj_money/state.cljs
+++ b/src/clj_money/state.cljs
@@ -30,6 +30,17 @@
 
 (def current-user (r/cursor app-state [:current-user]))
 (def current-entity (r/cursor app-state [:current-entity]))
+
+(def ^:private one-year-in-seconds (* 60 60 24 365))
+
+(add-watch current-entity
+           ::persist-last-entity
+           (fn [_ _ _ entity]
+             (when entity
+               (cookies/set! :last-entity-id
+                              (:id entity)
+                              {:max-age one-year-in-seconds}))))
+
 (def auth-token (r/cursor app-state [:auth-token]))
 (def profile-photo-url (r/cursor app-state [:profile-photo-url]))
 (def accounts (r/cursor app-state [:accounts]))
@@ -74,13 +85,20 @@
       (dissoc state :current-entity))
     state))
 
+(defn- find-entity-by-id
+  [id entities]
+  (->> entities
+       (filter #(= id (:id %)))
+       first))
+
 (defn set-entities
   [[entity :as entities]]
   (let [current (if-let [c @current-entity]
                   (->> entities
                        (filter #(util/entity= c %))
                        first)
-                  entity)]
+                  (or (find-entity-by-id (cookies/get :last-entity-id) entities)
+                      entity))]
     (swap! app-state assoc
            :entities entities
            :current-entity current)))

--- a/src/clj_money/state.cljs
+++ b/src/clj_money/state.cljs
@@ -97,7 +97,8 @@
                   (->> entities
                        (filter #(util/entity= c %))
                        first)
-                  (or (find-entity-by-id (cookies/get :last-entity-id) entities)
+                  (or (find-entity-by-id (cookies/get :last-entity-id)
+                                         entities)
                       entity))]
     (swap! app-state assoc
            :entities entities


### PR DESCRIPTION
## Summary
- The current entity was already persisted to the `:state` cookie (bundled with the auth token, current user, etc.), so it survived page reloads within a browser session — but that cookie is session-only (no `:max-age`), so the selection was lost after closing the browser or after a fresh login.
- Added a dedicated `:last-entity-id` cookie (1 year max-age) that's written whenever the current entity changes, independent of the session/auth cookie lifecycle.
- `set-entities` now falls back to matching this cookie's entity id when there's no current entity already in play (e.g. first load after closing the browser, or a fresh login), before falling back to the first entity in the list.

Closes Trello card #308 "Remember the last active entity".

## Test plan
- [x] `clj-kondo --lint src:test` passes with no errors/warnings
- [x] `lein fig:test` passes (106 tests, 370 assertions, 0 failures)
- [ ] Manually verify in browser: select a non-default entity, close the browser (or clear the session-only `state` cookie), sign back in, and confirm the previously selected entity is auto-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)