### PR TITLE
Surface account re-index failures instead of swallowing them

### DIFF
--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -607,27 +607,20 @@
 
 (defn propagate-account-from-start
   [entity account]
-  (try
-    (let [items (fetch-transaction-items account)
-          [{:account/keys [transaction-date-range]}
-           :as updates] (process-transaction-items account entity items)
-          updated (-> entity
-                      (update-in [:entity/transaction-date-range]
-                                 #(apply dates/push-boundary
-                                         %
-                                         transaction-date-range))
-                      entities/put)]
-      (->> updates
-           (partition-all 10)
-           (mapcat entities/put-many)
-           doall)
-      updated)
-    (catch Exception e
-      (log/errorf e
-                  "[propagation] Unable to propagate account %s (%s) "
-                  (:account/name account)
-                  (:id account))
-      entity)))
+  (let [items (fetch-transaction-items account)
+        [{:account/keys [transaction-date-range]}
+         :as updates] (process-transaction-items account entity items)
+        updated (-> entity
+                    (update-in [:entity/transaction-date-range]
+                               #(apply dates/push-boundary
+                                       %
+                                       transaction-date-range))
+                    entities/put)]
+    (->> updates
+         (partition-all 10)
+         (mapcat entities/put-many)
+         doall)
+    updated))
 
 (defn propagate-all
   [entity {:keys [progress-chan]}]
@@ -660,8 +653,16 @@
                             index
                             total)
                 account))
-         (reduce (comp notify-progress
-                       propagate-account-from-start)
+         (reduce (fn [entity account]
+                   (notify-progress
+                     (try
+                       (propagate-account-from-start entity account)
+                       (catch Exception e
+                         (log/errorf e
+                                     "[propagation] Unable to propagate account %s (%s) "
+                                     (:account/name account)
+                                     (:id account))
+                         entity))))
                  entity))))
 
 (prop/add-full-propagation propagate-all :priority 5)

--- a/test/clj_money/entities/transactions_test.clj
+++ b/test/clj_money/entities/transactions_test.clj
@@ -951,6 +951,74 @@
       (is (= 2500M (:account/quantity (reload-account "Checking")))
           "The account balance reflects the pre-existing item plus the new items exactly once"))))
 
+(def ^:private recalculate-context
+  (conj base-context
+        #:transaction{:transaction-date (t/local-date 2017 1 1)
+                      :entity "Personal"
+                      :description "Paycheck"
+                      :debit-account "Checking"
+                      :credit-account "Salary"
+                      :quantity 1000M}
+        #:transaction{:transaction-date (t/local-date 2017 2 1)
+                      :entity "Personal"
+                      :description "Paycheck"
+                      :debit-account "Checking"
+                      :credit-account "Salary"
+                      :quantity 1000M}))
+
+(dbtest recalculate-an-account-expands-the-date-range-to-include-later-transactions
+  (with-context recalculate-context
+    (let [entity (find-entity "Personal")
+          stale (-> (reload-account "Checking")
+                    (assoc :account/transaction-date-range
+                           [(t/local-date 2017 1 1) (t/local-date 2017 1 1)]))]
+      (entities/put stale)
+      (is (comparable? {:account/transaction-date-range [(t/local-date 2017 1 1)
+                                                         (t/local-date 2017 1 1)]}
+                       (reload-account "Checking"))
+          "sanity check: the stale, narrowed date range was persisted")
+      (transactions/propagate-account-from-start entity (entities/find stale))
+      (is (comparable? {:account/transaction-date-range [(t/local-date 2017 1 1)
+                                                          (t/local-date 2017 2 1)]}
+                       (reload-account "Checking"))
+          "The account transaction date range is expanded to include the later transaction")
+      (is (comparable? {:entity/transaction-date-range [(t/local-date 2017 1 1)
+                                                         (t/local-date 2017 2 1)]}
+                       (entities/find entity))
+          "The entity transaction date range is expanded to include the later transaction"))))
+
+(def ^:private no-price-context
+  (conj base-context
+        #:commodity{:name "Acme Fund"
+                    :entity "Personal"
+                    :symbol "ACME"
+                    :type :fund}
+        #:account{:name "Investment"
+                  :type :asset
+                  :entity "Personal"
+                  :commodity "ACME"}
+        #:transaction{:transaction-date (t/local-date 2017 1 1)
+                      :entity "Personal"
+                      :description "Buy shares"
+                      :debit-account "Investment"
+                      :credit-account "Checking"
+                      :quantity 10M}))
+
+(dbtest recalculate-throws-when-a-commoditys-price-cannot-be-determined
+  (with-context no-price-context
+    (let [entity (find-entity "Personal")
+          investment (reload-account "Investment")]
+      (is (thrown-with-msg? ExceptionInfo
+                            #"No price found for commodity"
+                            (transactions/propagate-account-from-start entity investment))
+          "The failure surfaces instead of being silently swallowed"))))
+
+(dbtest full-propagation-continues-past-an-account-with-no-price-data
+  (with-context no-price-context
+    (is (= [(t/local-date 2017 1 1) (t/local-date 2017 1 1)]
+           (:account/transaction-date-range (reload-account "Checking")))
+        "The Checking account is propagated normally even though the Investment account cannot be")))
+
 (def ^:private existing-reconciliation-context
   (conj (mapv (fn [entity]
                 (cond-> entity


### PR DESCRIPTION
## Summary

Trello #305: "Re-indexing an account fails to expand the transaction date range."

I traced the account row's "recalculate" (arrow clockwise) button through the full stack and could not reproduce the reported scenario directly — a faithful integration test of the exact button flow (narrow an account's stored `:account/transaction-date-range`, then recalculate with a transaction dated after the old upper bound) correctly expands the range on both the SQL and Datomic backends. I also ruled out hidden query limits, sort-order issues, and an "include children" gap analogous to #221 (that fix was scoped to reconciliation balances, a different code path).

What I did find: `propagate-account-from-start` wrapped its work in a blanket `try/catch` that silently swallowed *any* exception (e.g. a commodity price lookup failing when no price data exists) and just logged it, leaving the entity/account untouched with no error surfaced to the user. That means a recalculation that hits any failure silently "succeeds" without expanding anything — matching the reported symptom even though the date-range math itself is correct.

- Removed the blanket try/catch from `propagate-account-from-start` (the single-account path used by the recalculate button), so failures now propagate instead of being silently dropped.
- Moved the resilience this provided for bulk propagation (so one bad account doesn't abort import of the rest) into `propagate-all`'s per-account reduce step, where it belongs.

## Test plan
- [x] `lein test` — full suite, 951 tests / 2516 assertions, 0 failures/errors
- [x] `clj-kondo --lint src:test` — 0 errors/warnings
- [x] Added regression tests in `test/clj_money/entities/transactions_test.clj`:
  - `recalculate-an-account-expands-the-date-range-to-include-later-transactions` — confirms the core recalculate flow correctly expands a stale range
  - `recalculate-throws-when-a-commoditys-price-cannot-be-determined` — confirms a failure now surfaces instead of being swallowed
  - `full-propagation-continues-past-an-account-with-no-price-data` — confirms bulk propagation still tolerates one bad account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbmJCPKzYELCsZWzhoMj3L