### PR TITLE
Fix blank Payment Method/Category on receipt transaction edit

### DIFF
--- a/src/clj_money/views/receipts.cljs
+++ b/src/clj_money/views/receipts.cljs
@@ -91,8 +91,8 @@
          receipt
          [:receipt/items index :receipt-item/account]
          {:search-fn (search-accounts)
-          :find-fn (fn [id callback]
-                     (callback (@accounts-by-id id)))
+          :find-fn (fn [account callback]
+                     (callback (@accounts-by-id (:id account))))
           :on-change #(ensure-blank-item page-state)
           :caption-fn #(string/join "/" (:account/path %))}]]
    [:td [forms/decimal-input
@@ -153,8 +153,8 @@
         {:validations #{::v/required}
          :caption "Payment Method"
          :search-fn (search-accounts)
-         :find-fn (fn [id callback]
-                    (callback (@accounts-by-id id)))
+         :find-fn (fn [account callback]
+                    (callback (@accounts-by-id (:id account))))
          :caption-fn #(string/join "/" (:account/path %))}]
        [:table.table.table-borderless
         [:thead


### PR DESCRIPTION
## Summary
- Fixes Trello card #304: editing a receipt-entered transaction left the "Payment Method" and "Category" fields blank instead of populated.
- Root cause: `receipts/<-transaction` populates those fields with account entity-ref maps (`{:id ...}`), but the typeahead `find-fn` for those fields treated the value as a bare id when looking it up in `accounts-by-id`, so the lookup returned `nil` and the caption rendered empty.
- Fix: `find-fn` now extracts `:id` from the account ref before the lookup, in both the Payment Method field and each item's Category field.

## Test plan
- [ ] Manually verify in the Receipts view: enter a transaction, click the pencil icon on the resulting row, confirm Payment Method and Category are populated.
- [x] `clj-kondo --lint src/clj_money/views/receipts.cljs` passes with no errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbmJCPKzYELCsZWzhoMj3L