### PR TITLE
fix monitor w/ zero value

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -122,7 +122,7 @@
                  [ring-oauth2 "0.3.0" :exclusions [commons-codec]]
                  [camel-snake-kebab "0.4.3"]
                  [com.github.dgknght/app-lib
-                  "0.3.49"
+                  "0.3.50"
                   :exclusions
                   [stowaway
                    com.cognitect/transit-java

--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -243,15 +243,15 @@
 
 (defn last-transaction-item-on-or-before
   [{:as account :account/keys [transaction-date-range]} date]
-  {:pre [(:account/transaction-date-range account)]}
-  (entities/find-by (util/entity-type
-                      {:transaction-item/account account
-                       :transaction/transaction-date [:between
-                                                      (first transaction-date-range)
-                                                      date]}
-                      :transaction-item)
-                    {:sort [[:transaction/transaction-date :desc]
-                            [:transaction-item/index :desc]]}))
+  (when transaction-date-range
+    (entities/find-by (util/entity-type
+                        {:transaction-item/account account
+                         :transaction/transaction-date [:between
+                                                        (first transaction-date-range)
+                                                        date]}
+                        :transaction-item)
+                      {:sort [[:transaction/transaction-date :desc]
+                              [:transaction-item/index :desc]]})))
 
 (defn balance-delta
   "Returns the change in balance during the specified period for the specified account"

--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -241,7 +241,7 @@
       :transaction-item)
     {:sort [[:transaction-item/index :desc]]}))
 
-(defn- last-transaction-item-on-or-before
+(defn last-transaction-item-on-or-before
   [{:as account :account/keys [transaction-date-range]} date]
   {:pre [(:account/transaction-date-range account)]}
   (entities/find-by (util/entity-type

--- a/src/clj_money/reports.clj
+++ b/src/clj_money/reports.clj
@@ -42,19 +42,13 @@
 (def ^:private equity-header?
   (every-pred header? equity?))
 
-(defn- value-as-of
-  [a d]
-  (or (:transaction-item/balance (transactions/last-transaction-item-on-or-before a d))
-      0M))
-
 (defn- fetch-account-value
   [since as-of]
   (if since
     (fn [a]
-      (- (value-as-of a as-of)
-         (value-as-of a since)))
+      (transactions/balance-delta a since as-of))
     (fn [a]
-      (value-as-of a as-of))))
+      (transactions/balance-as-of a as-of))))
 
 (defn- balance-data
   [{:keys [accounts since as-of]}]

--- a/src/clj_money/reports.clj
+++ b/src/clj_money/reports.clj
@@ -7,7 +7,6 @@
             [java-time.api :as t]
             [dgknght.app-lib.core :refer [index-by]]
             [dgknght.app-lib.inflection :refer [humanize]]
-            [clj-money.find-in-chunks :as ch]
             [clj-money.entities :as entities]
             [clj-money.util :as util :refer [id= entity=]]
             [clj-money.dates :as dates :refer [earliest]]
@@ -43,67 +42,25 @@
 (def ^:private equity-header?
   (every-pred header? equity?))
 
-(defn- max-by-item-index
-  [items]
-  (when (seq items)
-    (apply max-key :transaction-item/index items)))
+(defn- value-as-of
+  [a d]
+  (or (:transaction-item/balance (transactions/last-transaction-item-on-or-before a d))
+      0M))
 
-(defn- last-item
-  [inclusion date items]
-  {:pre [(every? :transaction-item/index items)]}
-  (let [pred (case inclusion
-               :on-or-before (fn [{:transaction/keys [transaction-date]}]
-                               (or (= transaction-date date)
-                                   (t/before? transaction-date date)))
-               :before #(t/before? (:transaction/transaction-date %) date)
-               inclusion)]
-    (->> items
-         (filter pred)
-         max-by-item-index)))
-
-(defn- fetch-transaction-items
-  [account-ids as-of & {:as opts}]
-  (if (seq account-ids)
-    (ch/find account-ids
-             (merge
-               {:start-date as-of
-                :time-step (t/years 1)
-                :fetch-fn (fn [ids date]
-                            (entities/select
-                              (util/entity-type
-                                {:transaction-item/account [:in ids]
-                                 :transaction/transaction-date [:<between
-                                                                (t/minus date (t/years 1))
-                                                                date]}
-                                :transaction-item)
-                              {:select-also [:transaction/transaction-date]
-                               :datalog/hints [:transaction-item/account]}))
-                :id-fn (comp :id :transaction-item/account)
-                :find-one-fn (partial last-item :on-or-before as-of)}
-               opts))
-    {}))
+(defn- fetch-account-value
+  [since as-of]
+  (if since
+    (fn [a]
+      (- (value-as-of a as-of)
+         (value-as-of a since)))
+    (fn [a]
+      (value-as-of a as-of))))
 
 (defn- balance-data
-  [{:keys [accounts since as-of entity]}]
-  (let [earliest-date (get-in entity [:entity/transaction-date-range 0])
-        account-ids (->> accounts
-                         (map :id)
-                         set)
-        start-balances (when since
-                         (fetch-transaction-items
-                           account-ids
-                           since
-                           :find-one-fn (partial last-item :before since)
-                           :earliest-date earliest-date))
-        end-balances (fetch-transaction-items
-                       account-ids
-                       as-of
-                       :earliest-date earliest-date)]
-    (->> account-ids
-         (map (fn [id]
-                [id (- (get-in end-balances [id :transaction-item/balance] 0M)
-                       (get-in start-balances [id :transaction-item/balance] 0M))]))
-         (into {}))))
+  [{:keys [accounts since as-of]}]
+  (->> accounts
+       (map (juxt :id (fetch-account-value since as-of)))
+       (into {})))
 
 (defn- valuation-data
   [{:keys [entity accounts as-of] :as options}]

--- a/src/clj_money/views/dashboard.cljs
+++ b/src/clj_money/views/dashboard.cljs
@@ -34,9 +34,8 @@
 (defn- load-monitors
   [state]
   (if @current-entity
-    (do (+busy)
-        (reports/budget-monitors :callback -busy
-                                 :on-success #(swap! state assoc :monitors %)))
+    (reports/budget-monitors :on-success #(swap! state assoc :monitors %)
+                             :on-failure #(swap! state assoc :monitors []))
     (swap! state dissoc :monitors)))
 
 (defn- save-monitor
@@ -177,16 +176,16 @@
         monitors (r/cursor state [:monitors])
         new-monitor (r/cursor state [:new-monitor])
         monitors-with-detail (make-reaction
-                              (fn []
-                                (when (and @monitors @accounts-by-id)
-                                  (->> @monitors
-                                       (map (fn [m]
-                                              (-> m
-                                                  (update-in [:report/account] (comp @accounts-by-id
-                                                                                     :id))
-                                                  (assoc :report/scope @scope))))
-                                       (sort-by #(get-in % [:report/account :account/path]))
-                                       (into [])))))]
+                               (fn []
+                                 (when (and @monitors @accounts-by-id)
+                                   (->> @monitors
+                                        (map (fn [m]
+                                               (-> m
+                                                   (update-in [:report/account] (comp @accounts-by-id
+                                                                                      :id))
+                                                   (assoc :report/scope @scope))))
+                                        (sort-by #(get-in % [:report/account :account/path]))
+                                        (into [])))))]
     (load-monitors state)
     (add-watch current-entity ::monitors (fn [_ _ prev current]
                                            (if current
@@ -207,13 +206,16 @@
            [:div.visually-hidden "loading..."]]])
        (if @new-monitor
          [monitor-form state]
-         [button {:html {:on-click (fn []
-                                     (swap! state assoc :new-monitor {})
-                                     (set-focus "account-id"))
-                         :class "btn-secondary"
-                         :title "Click here to add a new budget monitor"}
-                  :caption "Add"
-                  :icon :plus}])])))
+         [:div.btn-group
+          [button {:html {:on-click (fn []
+                                      (swap! state assoc :new-monitor {})
+                                      (set-focus "account-id"))
+                          :class "btn-primary"
+                          :title "Click here to add a new budget monitor"}
+                   :icon :plus}]
+          [button {:html {:on-click #(load-monitors state)
+                          :class "btn-secondary"}
+                   :icon :arrow-clockwise}]])])))
 
 (defn- type-total
   [type accts]

--- a/test/clj_money/accounts_test.cljc
+++ b/test/clj_money/accounts_test.cljc
@@ -551,6 +551,29 @@
                    (valuation-data commodity-supplemental-data)
                    commodity-accounts)]
       #?(:clj (is (seq-of-maps-like? expected actual))
+         :cljs (is (dgknght.app-lib.test-assertions/seq-of-maps-like? expected actual)))))
+  (testing "A subset of accounts whose root's own parent is not included (as when valuating a single budget item and its children)"
+    (let [expected [{:account/name "Reserve"
+                     :account/value (d 10000)
+                     :account/total-value (d 12000)}
+                    {:account/name "Reserve Sub"
+                     :account/value (d 2000)
+                     :account/total-value (d 2000)}]
+          actual (accounts/valuate
+                   (valuation-data (update-in standard-supplemental-data
+                                              [:balances]
+                                              assoc :reserve-sub (d 2000)))
+                   [{:id :reserve
+                     :account/parent {:id :savings} ; :savings is NOT included in this subset
+                     :account/name "Reserve"
+                     :account/commodity {:id :usd}
+                     :account/type :asset}
+                    {:id :reserve-sub
+                     :account/parent {:id :reserve}
+                     :account/name "Reserve Sub"
+                     :account/commodity {:id :usd}
+                     :account/type :asset}])]
+      #?(:clj (is (seq-of-maps-like? expected actual))
          :cljs (is (dgknght.app-lib.test-assertions/seq-of-maps-like? expected actual))))))
 
 (deftest identity-an-action


### PR DESCRIPTION
Child accounts without a parent were being dropped in the nest/unnest portion of the valuation. app-lib was updated to treat them as root accounts.