### PR TITLE
Fix Cancel button on dashboard monitor add form

### DIFF
--- a/src/clj_money/views/dashboard.cljs
+++ b/src/clj_money/views/dashboard.cljs
@@ -80,7 +80,8 @@
          (icon-with-text :check "Save")]
         (html/space)
         [:button.btn.btn-secondary.ms-2
-         {:on-click #(swap! state dissoc :new-monitor)
+         {:type :button
+          :on-click #(swap! state dissoc :new-monitor)
           :title "Click here to close this form without creating a new monitor"}
          (icon-with-text :x "Cancel")]]])))
 


### PR DESCRIPTION
## Summary
- Trello #310: clicking Cancel on the dashboard's "add monitor" form failed to close it — a validation error was shown instead.
- Root cause: the Cancel button had no explicit `type`, so inside the `<form>` it defaulted to `type="submit"`. Clicking it ran the `on-click` handler (clearing `:new-monitor`) *and* triggered native form submission, which fired the form's `on-submit` handler, ran validation, and re-populated `:new-monitor` with an error before the form could close.
- Fix: set `:type :button` on the Cancel button so it no longer submits the form.

## Test plan
- [x] `clj-kondo --lint src:test` passes
- [x] Manually verified in the running app: opened the dashboard monitor add form, clicked Cancel with the Account field empty — form now closes with no validation error, and reopens/functions normally afterward.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn