### PR TITLE
Remember receipt payment method between entries

### DIFF
--- a/src/clj_money/views/receipts.cljs
+++ b/src/clj_money/views/receipts.cljs
@@ -29,7 +29,7 @@
   [page-state]
   (let [defaults (-> (get-in @page-state [:receipt])
                      (select-keys [:receipt/transaction-date
-                                   :receipt/account])
+                                   :receipt/payment-account])
                      (update-in [:receipt/transaction-date] (fnil identity (t/today)))
                      (assoc :receipt/items [{}]))]
     (swap! page-state assoc :receipt defaults)


### PR DESCRIPTION
## Summary
- `new-receipt` (called after each successful submission to reset the form) selected `:receipt/account` when carrying values forward, but the actual field used by the form, spec, and `->transaction`/`<-transaction` is `:receipt/payment-account`. The typo meant `select-keys` always dropped the value, so the Payment Method field was cleared on every new receipt.
- Fixed the key so the payment method now persists across consecutive receipt entries, letting the user enter several receipts against the same payment method without re-selecting it each time.

Trello card: https://trello.com/c/H7gJWLSD/301-remember-receipt-payment-method

## Test plan
- [x] `clj-kondo --lint src/clj_money/views/receipts.cljs` — 0 errors/warnings
- [x] `lein fig:test` — 106 tests, 371 assertions, 0 failures
- [ ] Manual check: submit a receipt, confirm Payment Method stays populated for the next entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn