### PR TITLE
Configure decimal rounding for receipt amount fields

### DIFF
--- a/src/clj_money/views/receipts.cljs
+++ b/src/clj_money/views/receipts.cljs
@@ -98,7 +98,8 @@
    [:td [forms/decimal-input
          receipt
          [:receipt/items index :receipt-item/quantity]
-         {:on-accept #(ensure-blank-item page-state)}]]
+         {:fraction-digits 2
+          :on-accept #(ensure-blank-item page-state)}]]
    [:td [forms/text-input
          receipt
          [:receipt/items index :receipt-item/memo]


### PR DESCRIPTION
## Summary
- The `:receipt-item/quantity` decimal input in the receipt entry form was missed when `:fraction-digits` support was rolled out to other decimal-input fields (e.g. the transaction entry forms use `{:fraction-digits 2}`), so it accepted unrounded amounts.
- Added `:fraction-digits 2` to match the currency-amount convention used elsewhere in the app.

Trello card: https://trello.com/c/1ltPJE4g/299-the-receipts-view-needs-decimal-rounding-configured-for-the-amount-fields

## Test plan
- [x] `clj-kondo --lint src/clj_money/views/receipts.cljs` — 0 errors/warnings
- [x] `lein fig:test` — 106 tests, 371 assertions, 0 failures
- [ ] Manual check: enter a receipt item amount with more than 2 decimal places and confirm it rounds/truncates to 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn