### PR TITLE
Fix decimal amount field dropping unspaced subtraction

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -122,7 +122,7 @@
                  [ring-oauth2 "0.3.0" :exclusions [commons-codec]]
                  [camel-snake-kebab "0.4.3"]
                  [com.github.dgknght/app-lib
-                  "0.3.50"
+                  "0.3.51"
                   :exclusions
                   [stowaway
                    com.cognitect/transit-java

--- a/test/clj_money/decimal_test.cljc
+++ b/test/clj_money/decimal_test.cljc
@@ -13,4 +13,6 @@
   (is (= (d/d 1000.0) (d/parse "1,000.0"))
       "A decimal formatted with commas is parsed into a decimal")
   (is (= (d/d 2) (d/parse "1+1"))
-      "A basic mathematical expression is calculated"))
+      "A basic mathematical expression is calculated")
+  (is (= (d/d 6) (d/parse "10-4"))
+      "Unspaced subtraction is calculated"))


### PR DESCRIPTION
## Summary
Fixes Trello #312: entering an equation like `10-4` into the Receipts "Amount" field silently ignored the `-4` and left `10` in place, instead of resolving to `6`. Spaced input (`10 - 4`) already worked correctly.

Root cause was in `dgknght.app-lib.math/eval` (used by the `decimal-input`/`decimal-field` form component, which the Amount field is built on): its tokenizing regex greedily attached a leading `-` to the number that follows, so `"10-4"` tokenized as `["10" "-4"]` (2 tokens) instead of `["10" "-" "4"]` (3 tokens). The PEMDAS evaluator requires an odd-length token stream and silently returns `nil` on anything else — and since the field's `parse-fn` only updates the model on a non-nil result, the input just kept showing the stale value.

Fixed upstream in dgknght/app-lib#47 by splitting a merged `-N` token back into a `-` operator and a positive number whenever it directly follows an operand (a number or closing paren), leaving genuine unary negatives (`-4`, `1+-4`, `2*-5`) untouched. Bumped this repo's `app-lib` dependency to `0.3.51` to pick up the fix.

**Note:** this PR depends on dgknght/app-lib#47 being merged and published to Clojars as `0.3.51` before it can be merged here — I've `lein install`ed it locally in the meantime to verify and test.

## Test plan
- [x] Added a regression case to `clj-money.decimal-test` for `(d/parse "10-4")` => `6`
- [x] Verified in app-lib: `lein test` (144 tests/422 assertions) and cljs test build (157 tests/475 assertions), both 0 failures, including new cases for `10-4`, `10-4-2`, `-4`, `1+-4`, `2*-5`, `3*(2+1)-4`
- [x] `lein test clj-money.decimal-test` passes against the locally installed `app-lib` `0.3.51`
- [x] `lein fig:test` (client tests) — 106 tests/371 assertions, 0 failures
- [x] `lein cloverage` — full suite 954 tests/2524 assertions, 0 failures
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)