### PR TITLE
Preserve item memo in the simplified transaction form

### DIFF
--- a/src/clj_money/transactions.cljc
+++ b/src/clj_money/transactions.cljc
@@ -691,9 +691,9 @@
          [this-item other-item] (f item)]
      (-> trx
          (assoc :transaction/other-account (:account-item/account other-item)
-                :transaction/other-item (util/->entity-ref other-item)
+                :transaction/other-item (select-keys other-item [:id :account-item/memo])
                 :transaction/account (:account-item/account this-item)
-                :transaction/item (util/->entity-ref this-item)
+                :transaction/item (select-keys this-item [:id :account-item/memo])
                 :transaction/quantity (:account-item/quantity this-item))
          (dissoc :transaction/items)))))
 

--- a/src/clj_money/transactions.cljc
+++ b/src/clj_money/transactions.cljc
@@ -352,7 +352,7 @@
   [{:as item :transaction-item/keys [account action]}]
   (-> item
       (rename-keys transaction->account-item-mappings)
-      (select-keys (vals transaction->account-item-mappings))
+      (select-keys (conj (vals transaction->account-item-mappings) :id))
       (update-in [:account-item/quantity] #(polarize-quantity
                                              {:account account
                                               :quantity %
@@ -489,7 +489,8 @@
                     :account-item/account :transaction-item/account
                     :account-item/action :transaction-item/action
                     :account-item/quantity :transaction-item/quantity})
-      (select-keys [:transaction-item/memo
+      (select-keys [:id
+                    :transaction-item/memo
                     :transaction-item/action
                     :transaction-item/quantity
                     :transaction-item/account])

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -802,7 +802,7 @@
                                                     (swap! transaction (expand-trx)))}
              (icon :arrows-expand)]
 
-            (can-accountify? @transaction)
+            (can-accountify? (->bilateral (unentryfy @transaction)))
             [:button.btn.btn-secondary {:title "Click here to simplify transaction entry."
                                         :on-click (fn [_]
                                                     (swap! transaction (collapse-trx page-state)))}

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -58,7 +58,9 @@
                                             accountified?
                                             can-accountify?
                                             entryfy
-                                            unentryfy]]
+                                            unentryfy
+                                            ->unilateral
+                                            ->bilateral]]
             [clj-money.views.transactions :as trns]
             [clj-money.views.reconciliations :as recs]
             [clj-money.views.attachments :as atts]))
@@ -770,6 +772,7 @@
     (-> trx
         v/reset
         unaccountify
+        ->unilateral
         entryfy)))
 
 (defn- collapse-trx
@@ -779,6 +782,7 @@
       (-> trx
           v/reset
           unentryfy
+          ->bilateral
           (accountify account)))))
 
 (defn- transaction-form

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -635,6 +635,7 @@
         [:transaction/transaction-date]
         {:validations #{::v/required}}]
        [forms/text-field transaction [:transaction/description] {:validations #{::v/required}}]
+       [forms/text-field transaction [:transaction/item :account-item/memo]]
        [forms/decimal-field transaction [:transaction/quantity] {:fraction-digits 2
                                                                  :validations #{::v/required}}]
        [forms/typeahead-field

--- a/test/clj_money/transactions_test.cljc
+++ b/test/clj_money/transactions_test.cljc
@@ -209,7 +209,11 @@
         (is (= "checking memo" (get-in recollapsed [:transaction/item :account-item/memo]))
             "This item's memo survives the round trip")
         (is (= "groceries memo" (get-in recollapsed [:transaction/other-item :account-item/memo]))
-            "The other item's memo survives the round trip")))))
+            "The other item's memo survives the round trip")
+        (is (= 201 (get-in recollapsed [:transaction/item :id]))
+            "This item's persisted id survives the round trip, so a subsequent save updates the existing item instead of creating a duplicate")
+        (is (= 202 (get-in recollapsed [:transaction/other-item :id]))
+            "The other item's persisted id survives the round trip")))))
 
 (deftest entryfy-a-transaction
   (let [transaction #:transaction{:transaction-date "2020-01-01"

--- a/test/clj_money/transactions_test.cljc
+++ b/test/clj_money/transactions_test.cljc
@@ -180,6 +180,37 @@
                                              :account {:id {:id 1}
                                                        :account/type :asset}})))))
 
+(deftest expand-and-collapse-a-simplified-transaction
+  (testing "Expanding a simplified transaction into the full item entry form, then
+           collapsing it back without adding or removing any items, reconstructs
+           a transaction that can be re-simplified"
+    (let [trx #:transaction{:transaction-date (dates/local-date "2020-01-01")
+                            :description "ACME Store"
+                            :memo "transaction memo"
+                            :items [{:id 1
+                                     :transaction-item/credit-item {:id 201
+                                                                    :account-item/account (accounts :checking)
+                                                                    :account-item/memo "checking memo"
+                                                                    :account-item/quantity (d/- d/zero (d 10))}
+                                     :transaction-item/debit-item {:id 202
+                                                                   :account-item/account (accounts :groceries)
+                                                                   :account-item/memo "groceries memo"
+                                                                   :account-item/quantity (d 10)}
+                                     :transaction-item/value (d 10)}]}
+          simple (trx/accountify trx (accounts :checking))
+          ; the same steps performed by expand-trx/collapse-trx in the accounts view
+          expanded (-> simple trx/unaccountify trx/->unilateral trx/entryfy)
+          collapsed (-> expanded trx/unentryfy trx/->bilateral)]
+      (is (trx/can-accountify? collapsed)
+          "The transaction can be re-simplified when no items were added or removed")
+      (let [recollapsed (trx/accountify collapsed (accounts :checking))]
+        (is (= (:transaction/quantity simple) (:transaction/quantity recollapsed))
+            "The quantity survives the round trip")
+        (is (= "checking memo" (get-in recollapsed [:transaction/item :account-item/memo]))
+            "This item's memo survives the round trip")
+        (is (= "groceries memo" (get-in recollapsed [:transaction/other-item :account-item/memo]))
+            "The other item's memo survives the round trip")))))
+
 (deftest entryfy-a-transaction
   (let [transaction #:transaction{:transaction-date "2020-01-01"
                                   :description "ACME Store"

--- a/test/clj_money/transactions_test.cljc
+++ b/test/clj_money/transactions_test.cljc
@@ -93,12 +93,13 @@
         expected #:transaction{:transaction-date "2020-01-01"
                                :description "ACME Store"
                                :memo "transaction memo"
-                               :item {:id 201}
+                               :item {:id 201 :account-item/memo "checking memo"}
                                :account (accounts :checking)
-                               :other-item {:id 202}
+                               :other-item {:id 202 :account-item/memo "groceries memo"}
                                :other-account (accounts :groceries)
                                :quantity (d -10)}]
-    (is (= expected (trx/accountify trx (accounts :checking))))))
+    (is (= expected (trx/accountify trx (accounts :checking)))
+        "The account-item memo is preserved for both items")))
 
 (deftest unaccountify-a-transaction
   (testing "A whole transaction"
@@ -160,7 +161,15 @@
                (trx/unaccountify (assoc simple
                                         :transaction/other-account
                                         {:id {:id 4}
-                                         :account/type :liability})))))))
+                                         :account/type :liability})))))
+      (testing "with memo on the items"
+        (is (= (-> expected
+                   (assoc-in [:transaction/items 0 :transaction-item/credit-item :account-item/memo] "credit memo")
+                   (assoc-in [:transaction/items 0 :transaction-item/debit-item :account-item/memo] "debit memo"))
+               (trx/unaccountify (assoc simple
+                                        :transaction/item {:id 1 :account-item/memo "credit memo"}
+                                        :transaction/other-item {:id 2 :account-item/memo "debit memo"})))
+            "The account-item memo entered in the simplified form is preserved through to the saved item"))))
   ; TODO: Is this still a valid use case?
   #_(testing "A partial transaction (for editing)"
       (is (= #:transaction{:transaction-date "2020-01-01"


### PR DESCRIPTION
## Summary

Card #314: the simplified (single-item) transaction form on the Accounts view had no memo field, even though the full multi-item form already lets you set a memo per line item.

Scope was narrowed during implementation from "add a whole-transaction-level memo field everywhere" to: **make `:transaction-item/memo` available in every form that touches transaction items.** Auditing the forms:

- `full-transaction-form` (multi-item) — already had a per-item memo field via `item-input-row`. No change needed.
- `scheduled.cljs` sched-tran form — already has memo per item. No change needed.
- Receipts view — already maps `:receipt-item/memo` through to `:transaction-item/memo` on save. No change needed.
- `simple-transaction-form` — **missing.** This is the form the card refers to.

## Part 1: memo field on the simplified form

Root cause: `accountify` collapses the transaction's single bilateral item down to a bare `{:id ...}` entity-ref via `util/->entity-ref`, which strips `:account-item/memo` along with everything else. That means even if a UI field existed, there was no data path for the memo to survive the accountify/unaccountify round trip used by this form.

- `clj_money.transactions/accountify`: preserve `:account-item/memo` (in addition to `:id`) when collapsing `:transaction/item` and `:transaction/other-item`. `unaccountify` already merges these maps back in during the reverse transform, so no change was needed there. Note `:account-item/*` is not a persisted schema entity — it's the same transient/internal namespace this pipeline already uses for `:account-item/account`, `:account-item/quantity`, `:account-item/action`; the field ultimately gets renamed to the real, schema-backed `:transaction-item/memo` before save (via the pre-existing `account->transaction-item` rename in `->unilateral`).
- `simple-transaction-form`: add a `[forms/text-field transaction [:transaction/item :account-item/memo]]` field, bound to the item for the account currently being viewed.
- Test coverage: `accountify-a-transaction` updated to assert memo is preserved for both items; new `testing` block in `unaccountify-a-transaction` covering the reverse direction.

## Part 2: fixed a broken expand/collapse round trip

While manually verifying "enter values in the simple form, expand to the full form, collapse back without adding items," the round trip was completely broken — collapsing back was impossible. Root cause, in `src/clj_money/views/accounts.cljs`:

- `expand-trx` called `entryfy` directly on `unaccountify`'s output. `unaccountify` returns a **bilateral** transaction (one item, nested `:credit-item`/`:debit-item`), but `entryfy` expects a **unilateral** transaction (flat items with top-level `:account`/`:action`/`:quantity`). Calling them back-to-back produced a garbage item with no usable data plus a stray empty item.
- `collapse-trx` had the mirror-image bug: it called `accountify` directly on `unentryfy`'s unilateral output, but `accountify` requires a single bilateral item. Since `unentryfy` filters out "empty" items (no debit/credit quantity), and the garbage item from the step above had none, every item got filtered out — `can-accountify?` was never true, so collapsing back always failed.

Fixed by inserting the already-existing `->unilateral` / `->bilateral` conversion functions at the right points:
```clojure
(defn- expand-trx []
  (fn [trx]
    (-> trx v/reset unaccountify ->unilateral entryfy)))

(defn- collapse-trx
  [page-state]
  (let [account (:view-account @page-state)]
    (fn [trx]
      (-> trx v/reset unentryfy ->bilateral (accountify account)))))
```

## Part 3: preserved persisted item ids through the round trip

Once the round trip actually worked (Part 2), a further problem surfaced: each item's persisted `:id` was silently dropped by the conversion, even though `accountify` already captures it on `:transaction/item`/`:transaction/other-item`. Root cause: `account->transaction-item` and `transaction->account-item` (the two directions of the bilateral↔unilateral item conversion, used internally by `->unilateral`/`->bilateral`) both `select-keys` away everything except a fixed field list that never included `:id`.

Fixed by adding `:id` to both `select-keys` lists. This is additive and doesn't touch the existing multi-item merge/pairing logic: the complex/multi-item test fixtures never set `:id` on individual items in the first place (they use a separate `:ids`-set mechanism at the wrapper level for partial-match slicing when editing multi-item transactions), so this only takes effect for items that already carry their own `:id` — exactly the case `accountify` populates for a simple 2-line transaction.

## Part 4: fixed the collapse button permanently disappearing after expanding

After Part 2/3, expand→collapse worked at the data-transform level, but the collapse icon itself never reappeared in the UI after clicking expand. Root cause: the button's visibility check called `can-accountify?` directly on the freshly-**entryfied** (flat) transaction. `can-accountify?` expects the bilateral shape (exactly one merged credit/debit item = a simplifiable pair) — but right after `entryfy`, a normal 2-sided transaction has **2** separate flat item maps, not 1, so the check always evaluated false and the button never showed.

Fixed by mirroring what `collapse-trx` itself does before checking — `(can-accountify? (->bilateral (unentryfy @transaction)))` — so the button's visibility matches what clicking it will actually produce. Verified false-for-3+-items / true-for-2-items via a REPL trace against both a freshly-expanded 2-item transaction and a genuine multi-item (paycheck-style) transaction.

## Test plan

- [x] `lein test clj-money.transactions-test` — 17 tests, 50 assertions, 0 failures
- [x] `lein test clj-money.transactions-test clj-money.api.transactions-test` — 32 tests, 94 assertions, 0 failures
- [x] `lein fig:test` (client cljs suite) — 107 tests, 378 assertions, 0 failures
- [x] `lein cloverage` (full backend suite) — 955 tests, 2531 assertions, 0 failures
- [x] `clj-kondo --lint src:test` on changed files — 0 errors, 0 warnings
- [x] Manual REPL verification of full round trip (accountify → unaccountify → ->unilateral → entryfy → unentryfy → ->bilateral → accountify), confirming quantity, memo, and item ids are all identical to the original, and that the collapse-button visibility predicate is true only when the transaction is actually simplifiable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn