### PR TITLE
Fix stale account cache after entering a receipt transaction

### DIFF
--- a/src/clj_money/cached_accounts.cljs
+++ b/src/clj_money/cached_accounts.cljs
@@ -1,6 +1,7 @@
 (ns clj-money.cached-accounts
   (:require [cljs.pprint :refer [pprint]]
             [clj-money.util :as util]
+            [clj-money.dates :refer [push-entity-boundary]]
             [clj-money.state :as state]
             [clj-money.accounts :refer [nest unnest]]
             [clj-money.api.accounts :as accts]))
@@ -16,6 +17,16 @@
 (defn latest
   [{:keys [id]}]
   (@state/accounts-by-id id))
+
+(defn push-transaction-date!
+  "Given an account and the date of a transaction that touches it, extends
+  the account's cached :account/transaction-date-range to include that
+  date, upserts the result into the shared accounts cache, and returns the
+  updated account."
+  [account date]
+  (let [updated (push-entity-boundary account :account/transaction-date-range date)]
+    (swap! state/accounts #(util/upsert-into updated {:sort-key :account/path} %))
+    updated))
 
 (defn watch-entity
   [_ _ previous current]

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -23,8 +23,7 @@
             [dgknght.app-lib.forms-validation :as v]
             [dgknght.app-lib.notifications :as notify]
             [dgknght.app-lib.bootstrap-5 :as bs]
-            [clj-money.dates :refer [serialize-local-date
-                                     push-entity-boundary]]
+            [clj-money.dates :refer [serialize-local-date]]
             [clj-money.util :as util :refer [id=]]
             [clj-money.icons :refer [icon
                                      icon-with-text]]
@@ -39,7 +38,8 @@
             [clj-money.api.prices :as prices]
             [clj-money.api.audit :as audit]
             [clj-money.cached-accounts :refer [fetch-accounts
-                                               latest]]
+                                               latest
+                                               push-transaction-date!]]
             [clj-money.commodities :as cmdts]
             [clj-money.accounts :as acts :refer [account-types
                                                  allocate
@@ -738,13 +738,6 @@
               :caption "Back"
               :icon :arrow-left-short}]]))
 
-(defn- upsert-account
-  [page-state]
-  (swap! accounts
-         #(util/upsert-into (:view-account @page-state)
-                            {:sort-key :account/path}
-                            %)))
-
 (defn- extract-trx-date
   [save-result]
   (if-let [date (:transaction/transaction-date save-result)]
@@ -756,15 +749,13 @@
 (defn- post-transaction-save
   [page-state]
   (fn [result]
-    (swap! page-state
-           (fn [state]
-             (-> state
-                 (dissoc :transaction :trade)
-                 (update-in [:view-account]
-                            push-entity-boundary
-                            :account/transaction-date-range
-                            (extract-trx-date result)))))
-    (upsert-account page-state)
+    (let [updated-account (push-transaction-date! (:view-account @page-state)
+                                                   (extract-trx-date result))]
+      (swap! page-state
+             (fn [state]
+               (-> state
+                   (dissoc :transaction :trade)
+                   (assoc :view-account updated-account)))))
     (trns/reset-item-loading page-state)))
 
 (defn- expand-trx []

--- a/src/clj_money/views/receipts.cljs
+++ b/src/clj_money/views/receipts.cljs
@@ -13,6 +13,7 @@
             [dgknght.app-lib.forms :as forms]
             [dgknght.app-lib.bootstrap-5 :as bs]
             [dgknght.app-lib.forms-validation :as v]
+            [clj-money.dates :refer [push-entity-boundary]]
             [clj-money.util :as util]
             [clj-money.icons :refer [icon
                                      icon-with-text]]
@@ -48,20 +49,45 @@
              :items (mapv #(select-keys % [:account-id :quantity :memo])
                           debit)}))))
 
+(defn- touched-account-ids
+  [{:receipt/keys [payment-account items]}]
+  (->> items
+       (map :receipt-item/account)
+       (cons payment-account)
+       (filter identity)
+       (map :id)
+       distinct))
+
+(defn- update-account-caches
+  "Advances the transaction-date-range of every account touched by the
+  receipt in the client-side accounts cache, so the Accounts view doesn't
+  need a full refresh to see the new transaction."
+  [receipt trx-date]
+  (doseq [id (touched-account-ids receipt)]
+    (when-let [account (@accounts-by-id id)]
+      (swap! accounts
+             #(util/upsert-into (push-entity-boundary account
+                                                       :account/transaction-date-range
+                                                       trx-date)
+                                {:sort-key :account/path}
+                                %)))))
+
 (defn- save-transaction
   [page-state]
-  (-> (:receipt @page-state)
-      receipts/->transaction
-      (trn/save
-        :callback -busy
-        :on-success (fn [trx]
-                      (swap! page-state
-                             update-in
-                             [:transactions]
-                             #(util/upsert-into trx
-                                                {:sort-key :transaction/transaction-date}
-                                                %))
-                      (new-receipt page-state)))))
+  (let [receipt (:receipt @page-state)]
+    (-> receipt
+        receipts/->transaction
+        (trn/save
+          :callback -busy
+          :on-success (fn [trx]
+                        (swap! page-state
+                               update-in
+                               [:transactions]
+                               #(util/upsert-into trx
+                                                  {:sort-key :transaction/transaction-date}
+                                                  %))
+                        (update-account-caches receipt (:receipt/transaction-date receipt))
+                        (new-receipt page-state))))))
 
 (defn- search-accounts []
   (fn [input callback]

--- a/src/clj_money/views/receipts.cljs
+++ b/src/clj_money/views/receipts.cljs
@@ -13,7 +13,7 @@
             [dgknght.app-lib.forms :as forms]
             [dgknght.app-lib.bootstrap-5 :as bs]
             [dgknght.app-lib.forms-validation :as v]
-            [clj-money.dates :refer [push-entity-boundary]]
+            [clj-money.cached-accounts :as cached-accts]
             [clj-money.util :as util]
             [clj-money.icons :refer [icon
                                      icon-with-text]]
@@ -65,12 +65,7 @@
   [receipt trx-date]
   (doseq [id (touched-account-ids receipt)]
     (when-let [account (@accounts-by-id id)]
-      (swap! accounts
-             #(util/upsert-into (push-entity-boundary account
-                                                       :account/transaction-date-range
-                                                       trx-date)
-                                {:sort-key :account/path}
-                                %)))))
+      (cached-accts/push-transaction-date! account trx-date))))
 
 (defn- save-transaction
   [page-state]


### PR DESCRIPTION
## Summary

Trello #319: newly entered receipt transactions weren't visible in the Accounts view until an entity switch or page refresh forced a full accounts re-fetch.

**Root cause:** `save-transaction` in `src/clj_money/views/receipts.cljs` only updated the receipts page's own local `:transactions` list on success — it never touched the shared client-side accounts cache (`state/accounts`). The Accounts view bounds its transaction-item fetch using each cached account's `:account/transaction-date-range`, so a receipt dated after that cached range was silently excluded from the fetch until the cache was rebuilt from the server.

**Fix:** after a successful receipt save, every account touched by the receipt (the payment account plus each item's account) has its cached `:account/transaction-date-range` advanced and is upserted back into the shared `accounts` cache — so the Accounts view sees the new transaction without needing a full refresh.

**DRY follow-up:** the Accounts view's own transaction-save flow already did the same "push the transaction date into the account's cached range, upsert into the shared cache" work (`upsert-account`/`post-transaction-save`). Extracted that shared logic into `clj-money.cached-accounts/push-transaction-date!`, next to the other functions that own mutations to the shared accounts cache (`fetch-accounts`, `latest`), and updated both views to call it instead of duplicating the `push-entity-boundary` + `upsert-into` logic.

## Test plan

- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [x] `lein fig:test` (full client suite) — 107 tests, 378 assertions, 0 failures
- [x] `lein cloverage` (full backend suite) — 955 tests, 2531 assertions, 0 failures
- [ ] Manual verification of the repro steps in card #319 against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn