### PR TITLE
Add ability to hide an account

### DIFF
--- a/resources/datomic/schema/account.edn
+++ b/resources/datomic/schema/account.edn
@@ -56,4 +56,8 @@
   :db/valueType :db.type/instant
   :db/cardinality :db.cardinality/one
   :db/noHistory true
-  :db/doc "The date of the price used to calculate the current value"}]
+  :db/doc "The date of the price used to calculate the current value"}
+ {:db/ident :account/hidden
+  :db/valueType :db.type/boolean
+  :db/cardinality :db.cardinality/one
+  :db/doc "Indicates the account should be hidden from default views and type-aheads"}]

--- a/src/clj_money/accounts.cljc
+++ b/src/clj_money/accounts.cljc
@@ -219,8 +219,8 @@
    #(find-by-path % accounts))
   ([term accounts]
    (filter #(and (not (:account/hidden %))
-                (match-path? (map string/lower-case (:account/path %))
-                             (map string/lower-case (string/split term #"/|:"))))
+                 (match-path? (map string/lower-case (:account/path %))
+                              (map string/lower-case (string/split term #"/|:"))))
            accounts)))
 
 (defn- tagged?

--- a/src/clj_money/accounts.cljc
+++ b/src/clj_money/accounts.cljc
@@ -218,8 +218,9 @@
   ([accounts]
    #(find-by-path % accounts))
   ([term accounts]
-   (filter #(match-path? (map string/lower-case (:account/path %))
-                         (map string/lower-case (string/split term #"/|:")))
+   (filter #(and (not (:account/hidden %))
+                (match-path? (map string/lower-case (:account/path %))
+                             (map string/lower-case (string/split term #"/|:"))))
            accounts)))
 
 (defn- tagged?

--- a/src/clj_money/api/accounts.clj
+++ b/src/clj_money/api/accounts.clj
@@ -75,7 +75,8 @@
    :account/system-tags
    :account/user-tags
    :account/parent
-   :account/allocations])
+   :account/allocations
+   :account/hidden])
 
 (defn- extract-account
   [{:keys [params]}]

--- a/src/clj_money/entities/accounts.clj
+++ b/src/clj_money/entities/accounts.clj
@@ -46,6 +46,7 @@
 (s/def :account/allocations (s/nilable (s/map-of ::entities/id decimal?)))
 (s/def :account/transaction-date-range (s/nilable (s/tuple dates/local-date?
                                                            dates/local-date?)))
+(s/def :account/hidden boolean?)
 
 (s/def ::entities/account (s/and (s/keys :req [:account/entity
                                              :account/type
@@ -55,7 +56,8 @@
                                                :account/system-tags
                                                :account/user-tags
                                                :account/allocations
-                                               :account/transaction-date-range])
+                                               :account/transaction-date-range
+                                               :account/hidden])
                                  name-is-unique?
                                  parent-has-same-type?))
 ; :value and :children-value are not specified because they are always
@@ -87,7 +89,8 @@
   [account]
   (-> account
       (update-in [:account/quantity] (fnil identity 0M))
-      (update-in [:account/value] (fnil identity 0M))))
+      (update-in [:account/value] (fnil identity 0M))
+      (update-in [:account/hidden] (fnil identity false))))
 
 (defn- before-save
   "Adjusts account data for saving in the database"

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -300,12 +300,17 @@
   [page-state]
   (let [raw-tags (r/cursor page-state [:filter-tags])
         filter-tags (make-reaction #(->> @raw-tags (map keyword) set))
-        filter-fn (make-reaction #(cond
-                                    (@filter-tags :_untagged) (fn [{:account/keys [user-tags]}]
-                                                                (empty? user-tags))
-                                    (seq @filter-tags) (fn [{:account/keys [user-tags]}]
-                                                         (seq (intersection @filter-tags user-tags)))
-                                    :else identity))
+        show-hidden? (r/cursor page-state [:show-hidden?])
+        tag-filter-fn (make-reaction #(cond
+                                        (@filter-tags :_untagged) (fn [{:account/keys [user-tags]}]
+                                                                    (empty? user-tags))
+                                        (seq @filter-tags) (fn [{:account/keys [user-tags]}]
+                                                             (seq (intersection @filter-tags user-tags)))
+                                        :else identity))
+        filter-fn (make-reaction #(every-pred @tag-filter-fn
+                                              (fn [account]
+                                                (or @show-hidden?
+                                                    (not (:account/hidden account))))))
         expanded (r/cursor page-state [:expanded])
         hide-zero-balances? (r/cursor page-state [:hide-zero-balances?])
         grouped (make-reaction #(group-by :account/type @accounts))]
@@ -566,6 +571,10 @@
           [:parent-only]
           {:caption "Prevent this account from receiving transaction items directly"
            :form-group-attr {:class (when-not (-> @account :account/parent :id) "d-none")}}]
+         [forms/checkbox-field
+          account
+          [:account/hidden]
+          {:caption "Hide this account from type-aheads and the account list by default"}]
          [:fieldset
           [:legend "Tags"]
           [forms/typeahead-input
@@ -1177,6 +1186,13 @@
          {:caption "Hide Zero-Balance Accounts"}]
         [:label.form-check-label {:for "hide-zero-balances"}
          "Hide zero balances"]]
+       [:div.form-check.mb-1
+        [forms/checkbox-input
+         page-state
+         [:show-hidden?]
+         {:caption "Show Hidden Accounts"}]
+        [:label.form-check-label {:for "show-hidden"}
+         "Show hidden accounts"]]
        [forms/checkbox-inputs
         page-state
         [:filter-tags]
@@ -1202,6 +1218,7 @@
 (defn- index []
   (let [page-state (r/atom {:expanded #{}
                             :hide-zero-balances? (any-non-zero-balances?)
+                            :show-hidden? false
                             :filter-tags #{}
                             :recalculating #{}
                             :ctl-chan (chan)})
@@ -1234,6 +1251,7 @@
                              (assoc
                                :expanded #{}
                                :filter-tags #{}
+                               :show-hidden? false
                                :hide-zero-balances? (any-non-zero-balances? accts))))
                  (load-commodities page-state)))
     (fn []

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -574,7 +574,7 @@
          [forms/checkbox-field
           account
           [:account/hidden]
-          {:caption "Hide this account from type-aheads and the account list by default"}]
+          {:caption "Hidden"}]
          [:fieldset
           [:legend "Tags"]
           [forms/typeahead-input

--- a/test/clj_money/accounts_test.cljc
+++ b/test/clj_money/accounts_test.cljc
@@ -332,6 +332,14 @@
     (is (= [["Receivable" "Eli"]]
            (map :account/path (accounts/find-by-path "Rec:Eli" accounts))))))
 
+(deftest find-account-by-path-excludes-hidden-accounts
+  (let [accounts [{:account/path ["Investments" "Fidelity"]}
+                  {:account/path ["Investments" "Hidden Fidelity"]
+                   :account/hidden true}]]
+    (is (= [["Investments" "Fidelity"]]
+           (map :account/path (accounts/find-by-path "Fidelity" accounts)))
+        "Hidden accounts are excluded from path search results")))
+
 (defn- test-polarization
   [account-type action quantity expected message]
   (let [account {:account/type account-type}]

--- a/test/clj_money/api/accounts_test.clj
+++ b/test/clj_money/api/accounts_test.clj
@@ -276,6 +276,17 @@
   (with-context
     (assert-blocked-update (update-an-account "jane@doe.com"))))
 
+(deftest a-user-can-hide-an-account-in-his-entity
+  (with-context
+    (assert-successful-update
+      (update-an-account "john@doe.com"
+                         :body #:account{:name "Checking"
+                                         :type :asset
+                                         :commodity {:id 1}
+                                         :hidden true})
+      :expected {:account/hidden true}
+      :expected-response {:account/hidden true})))
+
 (defn- delete-an-account
   [email]
   (with-context

--- a/test/clj_money/entities/accounts_test.clj
+++ b/test/clj_money/entities/accounts_test.clj
@@ -195,6 +195,16 @@
   (with-context account-context
     (assert-created (attributes))))
 
+(dbtest create-a-hidden-account
+  (with-context account-context
+    (assert-created (assoc (attributes) :account/hidden true))))
+
+(dbtest hidden-defaults-to-false
+  (with-context account-context
+    (let [account (entities/put (attributes))]
+      (is (false? (:account/hidden (entities/find account)))
+          "The hidden flag defaults to false when not specified"))))
+
 (def ^:private duplicate-name-context
   (conj select-context
         #:entity{:name "Business"
@@ -322,6 +332,11 @@
   (with-context tag-context
     (assert-updated (find-account "Rent")
                     {:account/user-tags #{:housing}})))
+
+(dbtest hide-an-account
+  (with-context update-context
+    (assert-updated (find-account "IRA")
+                    {:account/hidden true})))
 
 (dbtest replace-allocations
   (with-context update-context


### PR DESCRIPTION
## Summary
- Adds a first-class `:account/hidden` boolean, wired through the entity spec, Datomic schema, and API (the SQL column already existed, unused).
- Hidden accounts are excluded from account type-ahead search everywhere (`find-by-path`), covering the Parent field, transaction/receipt/scheduled-transaction/budget/dashboard account pickers.
- Hidden accounts are excluded from the Accounts view by default; a new "Show hidden accounts" checkbox in the filters drawer reveals them, following the existing "Hide Zero-Balance Accounts" pattern.
- Adds a "Hide this account..." checkbox to the account edit form.

Closes Trello card #315 (Hide an account).

## Test plan
- [x] `lein test clj-money.accounts-test clj-money.entities.accounts-test clj-money.api.accounts-test` — 0 failures
- [x] `clj-kondo --lint` on changed files — 0 errors/warnings
- [x] `lein fig:test` — 0 failures (cljs)
- [ ] Manual check in the browser: create an account, mark it hidden, confirm it disappears from the Accounts list and from account type-aheads, and reappears when "Show hidden accounts" is checked

Note: a full `lein test` run has 22 pre-existing failures / 13 pre-existing errors in `reports-test`/`api.reports-test`, confirmed present on `main` before this change (unrelated to this feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn