### PR TITLE
Direct link from scheduled transactions to their transaction edit form

### DIFF
--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -1228,6 +1228,10 @@
                                         @allocation-account
                                         @transaction))
         hide-funnel? (make-reaction #(or @selected @view-account))]
+    (when-let [{:keys [item account]} (:pending-transaction-item @app-state)]
+      (swap! app-state dissoc :pending-transaction-item)
+      (swap! page-state assoc :view-account account)
+      (trns/edit-transaction item page-state))
     (load-commodities page-state)
     (add-watch current-entity
                ::index

--- a/src/clj_money/views/scheduled.cljs
+++ b/src/clj_money/views/scheduled.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as string]
             [cljs-time.core :as t]
             [secretary.core :as secretary :include-macros true]
+            [accountant.core :as accountant]
             [reagent.core :as r]
             [reagent.ratom :refer [make-reaction]]
             [camel-snake-kebab.core :as csk]
@@ -388,10 +389,20 @@
                                         :on-click #(swap! page-state dissoc :selected)}
         (icon-with-text :x-circle "Cancel")]])))
 
+(defn- open-transaction
+  [trx]
+  (let [item (first (:transaction/items trx))
+        account (get-in @accounts-by-id [(get-in item [:transaction-item/account :id])])]
+    (swap! app-state assoc :pending-transaction-item {:item item
+                                                       :account account})
+    (accountant/navigate! "/accounts")))
+
 (defn- created-row
   [{:transaction/keys [transaction-date description value] :as trx}]
   ^{:key (str "created-transaction-row-" (:id trx))}
-  [:tr
+  [:tr {:style {:cursor "pointer"}
+        :title "Click here to view this transaction."
+        :on-click #(open-transaction trx)}
    [:td (format-date transaction-date)]
    [:td description]
    [:td (format-decimal value)]])

--- a/src/clj_money/views/scheduled.cljs
+++ b/src/clj_money/views/scheduled.cljs
@@ -29,6 +29,7 @@
                                      -busy
                                      busy?]]
             [clj-money.accounts :refer [find-by-path]]
+            [clj-money.cached-accounts :as cached-accts]
             [clj-money.scheduled-transactions :refer [next-transaction-date
                                                       pending? ]]
             [clj-money.api.scheduled-transactions :as sched-trans]))
@@ -71,11 +72,29 @@
                           sched-tran))
                       sched-trans)))))
 
+(defn- touched-account-ids
+  [{:transaction/keys [items]}]
+  (->> items
+       (map :transaction-item/account)
+       (filter identity)
+       (map :id)
+       distinct))
+
+(defn- update-account-caches
+  "Advances the transaction-date-range of every account touched by a
+  realized transaction in the client-side accounts cache, so the Accounts
+  view doesn't need a full refresh to see the new transaction."
+  [trx]
+  (doseq [id (touched-account-ids trx)]
+    (when-let [account (@accounts-by-id id)]
+      (cached-accts/push-transaction-date! account (:transaction/transaction-date trx)))))
+
 (defn- realize
   ([page-state] (realize nil page-state))
   ([sched-tran page-state]
    (+busy)
    (let [on-success (fn [result]
+                      (run! update-account-caches result)
                       (swap! page-state #(-> %
                                              (update-sched-trans result)
                                              (update-in [:created] (fnil concat []) result)))

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -65,7 +65,7 @@
          (update-in [:transaction/items] supply-accounts)
          prepare))))
 
-(defn- edit-transaction
+(defn edit-transaction
   [transaction-item page-state]
   (+busy)
   (transactions/get-by-transaction-item


### PR DESCRIPTION
## Summary
- Clicking a row in the "Created Transactions" table on the Scheduled Transactions view now navigates to the Accounts view and opens that transaction directly in the edit form, instead of leaving the user to find it manually.
- Fixes a stale account-cache bug found while testing this: realizing a scheduled transaction never advanced the cached `:account/transaction-date-range` for the accounts it touched, so a transaction dated outside that cached range wouldn't show up in the account's item list (same class of bug fixed for the Receipts view in #238).

## Test plan
- [x] `clj-kondo --lint src` passes
- [x] `lein fig:test` passes (108 tests, 379 assertions, 0 failures)
- [x] Manually verified in the browser: realized a scheduled transaction, clicked the created row, confirmed it opens directly in the Accounts view's transaction edit form, and confirmed the transaction now shows up in the account's item list even when dated outside the previously cached range

https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn