### PR TITLE
Replace abandoned mathieudutour/github-tag-action with semver-action

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -77,11 +77,24 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Determine next version
+        id: semver
+        uses: ietf-tools/semver-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          patchAll: true
+          noNewCommitBehavior: current
+          fallbackTag: v0.0.0
 
       - name: Tag with the version
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.semver.outputs.bump != 'none'
+        run: |
+          git tag ${{ steps.semver.outputs.next }}
+          git push origin ${{ steps.semver.outputs.next }}
 
   publish-prep:
     needs: tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,3 +35,4 @@ We own two of the libraries used throughout this projects.
   - Review the documentation and ensure that it is up-to-date.
   - Run unit tests with code coverage to ensure all tests pass
     and coverage has not slipped below the configured minimum.
+- Use [Conventional Commit](https://www.conventionalcommits.org/) messages


### PR DESCRIPTION
## Summary
- `mathieudutour/github-tag-action@v6.2` is unmaintained (no release since the repo went dark on 2024-08-30) and still declares `using: "node20"`, which GitHub currently runs via a temporary Node 24 compatibility shim. When GitHub drops that shim, the `tag` job would hard-fail.
- Replaces it with `ietf-tools/semver-action`, mirroring the same fix already applied in `clj-groceries` (commit `1ed70d1`): checkout with full history, compute the next semver tag, then tag and push it only when a bump is warranted.

## Test plan
- [x] `.github/workflows/clojure.yml` validated as well-formed YAML
- [x] No other workflow files reference the old action
- [ ] Confirm the `tag` job succeeds on the next push to `main` (can't be tested from a feature branch since the job only runs `if: github.event_name == 'push'` on `main`)

https://claude.ai/code/session_0144dicm9PoGkTqygYfrMXSn