### PR TITLE
fix: implement transaction-items delete API call

### DIFF
--- a/src/clj_money/api/transaction_items.cljs
+++ b/src/clj_money/api/transaction_items.cljs
@@ -57,6 +57,7 @@
            (add-error-handler opts "Unable to retrieve the transaction item summary: %s")))
 
 (defn delete
-  "Deletes the transaction containing the specified account item"
-  [& _]
-  (throw (js/Error. "Not implemented")))
+  "Deletes the transaction containing the specified transaction item"
+  [transaction-item & {:as opts}]
+  (api/delete (api/path :transactions (:transaction-item/transaction transaction-item))
+              (add-error-handler opts "Unable to delete the transaction: %s")))


### PR DESCRIPTION
## Summary
- The client-side `clj-money.api.transaction-items/delete` function was an unimplemented stub that unconditionally threw `Error. "Not implemented"`.
- Clicking the delete ("x") button on a transaction row and confirming would throw before the busy-state callback ran, leaving the UI stuck in a busy state and the transaction not deleted.
- Implemented `delete` to call the existing `DELETE /api/transactions/:id` endpoint against the item's parent transaction, mirroring the pattern used by `accounts.cljs`/`attachments.cljs`. The backend already cascades the delete to remove all associated transaction items.

## Test plan
- [x] `clj-kondo --lint src:test` passes with no errors/warnings
- [x] `lein fig:test` — 108 tests, 379 assertions, 0 failures/errors
- [ ] Manually verify in the browser: Accounts page → select an account with items → click "x" on a transaction row → confirm → item is deleted and busy state clears

Fixes Trello card #328 (Unable to delete transaction item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)