### PR TITLE
fix: allow unchecking a reconciled item on a working reconciliation

### DIFF
--- a/src/clj_money/db/datomic/reconciliations.clj
+++ b/src/clj_money/db/datomic/reconciliations.clj
@@ -1,14 +1,15 @@
 (ns clj-money.db.datomic.reconciliations
   (:require [clj-money.util :as util]
+            [clj-money.entities.reconciliations :as recs]
             [clj-money.db.datomic :as datomic]))
 
 (defmethod datomic/deconstruct :reconciliation
-  [{:as recon :reconciliation/keys [items removed-items]}]
+  [{:as recon :reconciliation/keys [items]}]
   (let [r (-> recon
               util/+id
-              (dissoc :reconciliation/items :reconciliation/removed-items))]
+              (dissoc :reconciliation/items))]
     (concat [r]
             (map #(assoc % :transaction-item/reconciliation r)
                  items)
             (map #(assoc % :transaction-item/reconciliation nil)
-                 removed-items))))
+                 (::recs/removed-items (meta recon))))))

--- a/src/clj_money/db/datomic/reconciliations.clj
+++ b/src/clj_money/db/datomic/reconciliations.clj
@@ -3,10 +3,12 @@
             [clj-money.db.datomic :as datomic]))
 
 (defmethod datomic/deconstruct :reconciliation
-  [{:as recon :reconciliation/keys [items]}]
+  [{:as recon :reconciliation/keys [items removed-items]}]
   (let [r (-> recon
               util/+id
-              (dissoc :reconciliation/items))]
-    (cons r
-          (map #(assoc % :transaction-item/reconciliation r)
-               items))))
+              (dissoc :reconciliation/items :reconciliation/removed-items))]
+    (concat [r]
+            (map #(assoc % :transaction-item/reconciliation r)
+                 items)
+            (map #(assoc % :transaction-item/reconciliation nil)
+                 removed-items))))

--- a/src/clj_money/db/sql/reconciliations.clj
+++ b/src/clj_money/db/sql/reconciliations.clj
@@ -12,7 +12,9 @@
        reconciliations))
 
 (defmethod sql/deconstruct :reconciliation
-  [{:as recon :keys [id] :reconciliation/keys [items]}]
-  (cons (dissoc recon :reconciliation/items)
-        (mapv #(assoc % :transaction-item/reconciliation {:id id})
-              items)))
+  [{:as recon :keys [id] :reconciliation/keys [items removed-items]}]
+  (concat [(dissoc recon :reconciliation/items :reconciliation/removed-items)]
+          (mapv #(assoc % :transaction-item/reconciliation {:id id})
+                items)
+          (mapv #(assoc % :transaction-item/reconciliation nil)
+                removed-items)))

--- a/src/clj_money/db/sql/reconciliations.clj
+++ b/src/clj_money/db/sql/reconciliations.clj
@@ -1,5 +1,6 @@
 (ns clj-money.db.sql.reconciliations
   (:require [clj-money.db :as db]
+            [clj-money.entities.reconciliations :as recs]
             [clj-money.db.sql :as sql]))
 
 (defmethod sql/post-select :reconciliation
@@ -12,9 +13,9 @@
        reconciliations))
 
 (defmethod sql/deconstruct :reconciliation
-  [{:as recon :keys [id] :reconciliation/keys [items removed-items]}]
+  [{:as recon :keys [id] :reconciliation/keys [items]}]
   (concat [(dissoc recon :reconciliation/items :reconciliation/removed-items)]
           (mapv #(assoc % :transaction-item/reconciliation {:id id})
                 items)
           (mapv #(assoc % :transaction-item/reconciliation nil)
-                removed-items)))
+                (::recs/removed-items (meta recon)))))

--- a/src/clj_money/entities/reconciliations.clj
+++ b/src/clj_money/entities/reconciliations.clj
@@ -255,12 +255,12 @@
                                               [:transaction-item/account]
                                               (comp accounts :id)))))]
     (-> recon
-        (assoc :reconciliation/removed-items removed-items)
         (update-in [:reconciliation/status] (fnil identity :new))
         (vary-meta
           #(assoc %
                   ::accounts accounts
                   ::new-items new-items
+                  ::removed-items removed-items
                   ::all-items all-items
                   ::existing-items existing-items
                   ::last-completed (find-last-completed recon))))))

--- a/src/clj_money/entities/reconciliations.clj
+++ b/src/clj_money/entities/reconciliations.clj
@@ -237,18 +237,25 @@
         existing-items (if (:id recon)
                          (fetch-transaction-items recon)
                          [])
-        ignore? (comp (->> existing-items
-                           (map :id)
-                           set)
-                      :id)
-        new-items (remove ignore? items)
+        existing? (comp (->> existing-items
+                             (map :id)
+                             set)
+                        :id)
+        new-items (remove existing? items)
+        submitted? (comp (->> items
+                              (map :id)
+                              set)
+                         :id)
+        kept-items (filter submitted? existing-items)
+        removed-items (remove submitted? existing-items)
         all-items (->> new-items
-                       (concat existing-items)
+                       (concat kept-items)
                        (map (comp polarize-item
                                   #(update-in %
                                               [:transaction-item/account]
                                               (comp accounts :id)))))]
     (-> recon
+        (assoc :reconciliation/removed-items removed-items)
         (update-in [:reconciliation/status] (fnil identity :new))
         (vary-meta
           #(assoc %

--- a/test/clj_money/entities/reconciliations_test.clj
+++ b/test/clj_money/entities/reconciliations_test.clj
@@ -559,7 +559,9 @@
                        (update-in (entities/find item)
                                   [:transaction-item/reconciliation]
                                   identity))
-          "The previously reconciled item is no longer linked to the reconciliation"))))
+          "The previously reconciled item is no longer linked to the reconciliation")
+      (is (empty? (:reconciliation/items (entities/find result)))
+          "The retrieved reconciliation no longer includes the removed item"))))
 
 (dbtest an-unadjusted-balance-fails-after-removing-an-item
   (with-context working-recon-context

--- a/test/clj_money/entities/reconciliations_test.clj
+++ b/test/clj_money/entities/reconciliations_test.clj
@@ -540,6 +540,36 @@
                      item)
           (assert-invalid {:reconciliation/balance ["Balance must match the calculated balance"]})))))
 
+(dbtest an-item-can-be-removed-from-a-working-reconciliation
+  (with-context working-recon-context
+    (let [checking (find-account "Checking")
+          item (find-transaction-item [(t/local-date 2017 1 2)
+                                   500M
+                                   checking])
+          result (-> (find-reconciliation [checking (t/local-date 2017 1 3)])
+                     entities/find ; get a fresh copy of the account items
+                     (assoc :reconciliation/items []
+                            :reconciliation/balance 1000M)
+                     entities/put)]
+      (is (comparable? #:reconciliation{:balance 1000M
+                                        :status :new}
+                       result)
+          "The result reflects the updated balance")
+      (is (comparable? {:transaction-item/reconciliation nil}
+                       (update-in (entities/find item)
+                                  [:transaction-item/reconciliation]
+                                  identity))
+          "The previously reconciled item is no longer linked to the reconciliation"))))
+
+(dbtest an-unadjusted-balance-fails-after-removing-an-item
+  (with-context working-recon-context
+    (let [checking (find-account "Checking")]
+      (-> (find-reconciliation [checking (t/local-date 2017 1 3)])
+          entities/find ; get a fresh copy of the account items
+          (assoc :reconciliation/items []
+                 :reconciliation/status :completed)
+          (assert-invalid {:reconciliation/balance ["Balance must match the calculated balance"]})))))
+
 (dbtest a-completed-reconciliation-cannot-be-updated
   (with-context existing-reconciliation-context
     (-> (find-reconciliation ["Checking" (t/local-date 2017 1 1)])

--- a/test/clj_money/entities/reconciliations_test.clj
+++ b/test/clj_money/entities/reconciliations_test.clj
@@ -560,7 +560,7 @@
                                   [:transaction-item/reconciliation]
                                   identity))
           "The previously reconciled item is no longer linked to the reconciliation")
-      (is (empty? (:reconciliation/items (entities/find result)))
+      (is (empty? (-> result entities/find :reconciliation/items))
           "The retrieved reconciliation no longer includes the removed item"))))
 
 (dbtest an-unadjusted-balance-fails-after-removing-an-item


### PR DESCRIPTION
## Summary
- Fixes Trello #327: unchecking an erroneously-reconciled transaction item on a working reconciliation and completing it always failed server-side, and the item stayed reconciled.
- `before-validation` for `:reconciliation` was unconditionally re-including every item already linked to the reconciliation (fetched fresh from the DB) when computing the calculated balance, ignoring items the client removed from the submission. The calculated balance therefore could never exclude a wrongly-checked item.
- Persistence had the same gap: items dropped from the submitted `:reconciliation/items` list were never unlinked (`:transaction-item/reconciliation` was left pointing at the reconciliation).
- `before-validation` now splits previously-linked items into "kept" (still submitted) and "removed" (dropped from the submission), excludes removed items from the balance calculation, and passes them through as `:reconciliation/removed-items` so the SQL and Datomic `deconstruct` implementations clear the FK/ref for those items.

## Test plan
- [x] `lein test :only clj-money.entities.reconciliations-test` — added `an-item-can-be-removed-from-a-working-reconciliation` and `an-unadjusted-balance-fails-after-removing-an-item`
- [x] `lein test :only clj-money.api.reconciliations-test`
- [x] `lein test` (full suite): 973 tests, 0 failures
- [x] `lein cloverage` on the touched namespaces: `db.sql.reconciliations` 100%, `db.datomic.reconciliations` 100%, `entities.reconciliations` 96.24%/99.44%
- [x] `clj-kondo --lint`

https://claude.ai/code/session_01MJxoKobBGHLt2NWseMZDov