### PR TITLE
fix: keep account group order stable in accounts view

### DIFF
--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -316,7 +316,10 @@
         grouped (make-reaction #(group-by :account/type @accounts))]
     (fn []
       [:tbody
-       (->> @grouped
+       (->> account-types
+            (keep (fn [account-type]
+                    (when-let [group (get @grouped account-type)]
+                      [account-type group])))
             (mapcat (fn [[account-type group]]
                       (cons (account-type-row account-type
                                               group


### PR DESCRIPTION
## Summary
- Fixes Trello #325: account group order in the Accounts view drifted during usage (e.g. `Expense, Equity, Income, Liability, Asset` instead of `Asset, Liability, Equity, Income, Expense`).
- Root cause: `account-and-type-rows` grouped accounts with `group-by`, then iterated the resulting map directly. Plain maps don't guarantee a stable order — it tracked whichever account type happened to appear first in the `accounts` state vector, which shifts as accounts are added/edited.
- Fix: iterate the canonical `account-types` order (`clj-money.accounts/account-types`) and look up each group, skipping types with no accounts.

## Test plan
- [x] `clj-kondo --lint src:test` — clean
- [x] `lein test` — 969 tests, 0 failures, 0 errors
- [ ] Manual check in the browser: reorder/add accounts across types in the Accounts view and confirm group order stays Asset, Liability, Equity, Income, Expense

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJxoKobBGHLt2NWseMZDov