### PR TITLE
fix: scope reconciled-item guard to quantity, action, and account

### DIFF
--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -18,18 +18,10 @@
             [clj-money.accounts :as acts]))
 
 (defn- unbox
-  "Takes a function and returns a function that takes a single argument
-  and if that argument is a vector, extracts the second element and passes
-  it to the given function, otherwise passes the argument as-is.
-
-  This is because the transaction specs use 'or' specs, which can
-  result in maps being wrapped in tuples with the branch of the matching
-  'or' in the first position."
-  [f]
-  (fn [x]
-    (f (if (vector? x)
-         (second x)
-         x))))
+  "Takes either an entity or a tuple containing and entity
+  in the second position and returns the entity."
+  [x]
+  (if (vector? x) (second x) x))
 
 (defn- new-transaction-has-items?
   [input]
@@ -55,13 +47,10 @@
             {:message "A parent-only account cannot receive transaction items"
              :path [:transaction/items]})
 
-(defn- unbox-item
-  [item]
-  (if (vector? item) (second item) item))
-
 (defn- qty-comparable
   [item]
-  (-> (unbox-item item)
+  (-> item
+      unbox
       (select-keys [:id
                     :transaction-item/quantity
                     :transaction-item/action
@@ -76,7 +65,7 @@
     (if (nil? items)
       true
       (let [after (->> items
-                       (map (juxt (comp :id unbox-item) qty-comparable))
+                       (map (juxt (comp :id unbox) qty-comparable))
                        (into {}))]
         (->> (reconciled-items-for-trx trx)
              (map qty-comparable)
@@ -85,7 +74,8 @@
     true))
 
 (def ^:private no-reconciled-quantities-changed?
-  (unbox no-reconciled-quantities-changed*))
+  (comp no-reconciled-quantities-changed*
+        unbox))
 
 (v/reg-spec no-reconciled-quantities-changed? {:message "A reconciled quantity cannot be updated"
                                                :path [:transaction/items]})

--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -55,9 +55,18 @@
             {:message "A parent-only account cannot receive transaction items"
              :path [:transaction/items]})
 
+(defn- unbox-item
+  [item]
+  (if (vector? item) (second item) item))
+
 (defn- qty-comparable
   [item]
-  (select-keys item [:id :transaction-item/quantity]))
+  (-> (unbox-item item)
+      (select-keys [:id
+                    :transaction-item/quantity
+                    :transaction-item/action
+                    :transaction-item/account])
+      (update :transaction-item/account :id)))
 
 (declare reconciled-items-for-trx)
 
@@ -67,7 +76,7 @@
     (if (nil? items)
       true
       (let [after (->> items
-                       (map (juxt :id qty-comparable))
+                       (map (juxt (comp :id unbox-item) qty-comparable))
                        (into {}))]
         (->> (reconciled-items-for-trx trx)
              (map qty-comparable)

--- a/test/clj_money/entities/transactions_test.clj
+++ b/test/clj_money/entities/transactions_test.clj
@@ -1096,6 +1096,36 @@
       (is (entities/find transaction)
           "The transaction can be retrieved after failed delete attempt"))))
 
+(dbtest the-memo-of-a-reconciled-item-can-be-changed
+  (with-context existing-reconciliation-context
+    (let [transaction (find-transaction [(t/local-date 2017 1 1) "Paycheck"])]
+      (-> transaction
+          (assoc-in [:transaction/items 0 :transaction-item/memo] "Updated memo")
+          entities/put)
+      (is (= "Updated memo"
+             (->> (entities/find transaction)
+                  :transaction/items
+                  (some :transaction-item/memo)))
+          "The memo change is persisted"))))
+
+(dbtest the-description-of-a-transaction-with-a-reconciled-item-can-be-changed
+  (with-context existing-reconciliation-context
+    (let [transaction (find-transaction [(t/local-date 2017 1 1) "Paycheck"])]
+      (-> transaction
+          (assoc :transaction/description "Paycheck (updated)")
+          entities/put)
+      (is (= "Paycheck (updated)"
+             (:transaction/description (entities/find transaction)))
+          "The description change is persisted"))))
+
+(dbtest the-account-of-a-reconciled-item-cannot-be-changed
+  (with-context existing-reconciliation-context
+    (let [rent (find-account "Rent")]
+      (-> (find-transaction [(t/local-date 2017 1 1) "Paycheck"])
+          (assoc-in [:transaction/items 0 :transaction-item/account] rent)
+          (assert-invalid
+            {:transaction/items ["A reconciled quantity cannot be updated"]})))))
+
 (def ^:private migrate-context
   (conj base-context
         #:account{:name "Savings"


### PR DESCRIPTION
## Summary
- Fixes Trello #331 — the reconciled-transaction-item guard was rejecting *any* edit to a transaction that had a reconciled item, not just changes to quantity, action, or account.
- Root cause: items reach the guard already conformed as `[:unilateral item]` tuples (from an earlier alternative in the `::entities/transaction` spec), so `:id` lookups silently returned `nil` and every item collapsed to the same comparable value. The existing quantity/action tests happened to pass because that false positive matched their expected (invalid) outcome — but it also incorrectly blocked date/description/memo edits.
- Unboxes items before comparing and extends the comparison to also flag account changes, per the card's description of intended behavior.

## Test plan
- [x] `lein test :only clj-money.entities.transactions-test` (79 tests, 0 failures)
- [x] `lein test :only clj-money.entities.transaction-items-test`
- [x] `lein test :only clj-money.api.transactions-test`
- [x] `lein test :only clj-money.entities.scheduled-transactions-test`
- [x] `clj-kondo --lint src:test`
- [x] Added coverage: memo edit allowed, description edit allowed, account change rejected (quantity/action rejection already covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJxoKobBGHLt2NWseMZDov