### PR TITLE
feat: expose memo field for payment method in receipt entry

### DIFF
--- a/src/clj_money/receipts.cljc
+++ b/src/clj_money/receipts.cljc
@@ -32,13 +32,15 @@
 (s/def :receipt/transaction-date dates/local-date?)
 (s/def :receipt/description string?)
 (s/def :receipt/payment-account ::entity-ref)
+(s/def :receipt/payment-memo (s/nilable string?))
 (s/def :receipt/items (s/coll-of ::receipt-item))
 (s/def :receipt/transaction-id ::id)
 (s/def ::receipt (s/and (s/keys :req [:receipt/transaction-date
                                       :receipt/description
                                       :receipt/payment-account
                                       :receipt/items]
-                                :opt [:receipt/transaction-id])
+                                :opt [:receipt/transaction-id
+                                      :receipt/payment-memo])
                         item-polarity-aligns?))
 
 (defn- ->transaction-item
@@ -59,6 +61,7 @@
                    transaction-id
                    description
                    payment-account
+                   payment-memo
                    items]
     :as receipt}]
   {:pre [(s/valid? ::receipt receipt)]}
@@ -70,6 +73,7 @@
                           :transaction-date transaction-date
                           :items (cons #:transaction-item{:account payment-account
                                                           :action payment-action
+                                                          :memo payment-memo
                                                           :quantity (d/abs total)}
                                        (->> items
                                             (remove empty-item?)
@@ -93,4 +97,5 @@
               :transaction-id (:id trx)
               :description description
               :payment-account (:transaction-item/account payment)
+              :payment-memo (:transaction-item/memo payment)
               :items (mapv <-transaction-item expenses)}))

--- a/src/clj_money/views/receipts.cljs
+++ b/src/clj_money/views/receipts.cljs
@@ -180,6 +180,7 @@
          :find-fn (fn [account callback]
                     (callback (@accounts-by-id (:id account))))
          :caption-fn #(string/join "/" (:account/path %))}]
+       [forms/text-field receipt [:receipt/payment-memo] {:caption "Payment Memo"}]
        [:table.table.table-borderless
         [:thead
          [:tr

--- a/test/clj_money/receipts_test.cljc
+++ b/test/clj_money/receipts_test.cljc
@@ -10,7 +10,8 @@
                        :description "Kroger"
                        :items [#:transaction-item{:action :credit
                                                   :account {:id :checking}
-                                                  :quantity 100M}
+                                                  :quantity 100M
+                                                  :memo nil}
                                #:transaction-item{:action :debit
                                                   :account {:id :groceries}
                                                   :quantity 100M
@@ -27,7 +28,8 @@
           :transaction/description "Kroger"
           :transaction/items [#:transaction-item{:action :credit
                                                  :account {:id :checking}
-                                                 :quantity 100M}
+                                                 :quantity 100M
+                                                 :memo "cash back"}
                               #:transaction-item{:action :debit
                                                  :account {:id :groceries}
                                                  :quantity 100M
@@ -36,15 +38,17 @@
                                            :transaction-id "abc123"
                                            :description "Kroger"
                                            :payment-account {:id :checking}
+                                           :payment-memo "cash back"
                                            :items [#:receipt-item{:account {:id :groceries}
                                                                   :quantity 100M
                                                                   :memo "weekly stuff"}]}))
-      "A transaction id is preserved during the conversion")
+      "A transaction id and payment memo are preserved during the conversion")
   (is (= #:transaction{:transaction-date (dates/local-date "2020-01-01")
                        :description "Kroger"
                        :items [#:transaction-item{:action :debit
                                                   :account {:id :checking}
-                                                  :quantity 10M}
+                                                  :quantity 10M
+                                                  :memo nil}
                                #:transaction-item{:action :credit
                                                   :account {:id :groceries}
                                                   :quantity 10M
@@ -60,7 +64,8 @@
                        :description "Kroger"
                        :items [#:transaction-item{:action :credit
                                                   :account {:id :checking}
-                                                  :quantity 100M}
+                                                  :quantity 100M
+                                                  :memo nil}
                                #:transaction-item{:action :debit
                                                   :account {:id :groceries}
                                                   :quantity 100M
@@ -100,6 +105,7 @@
                    :transaction-id "abc123"
                    :description "Kroger"
                    :payment-account {:id :checking}
+                   :payment-memo "cash back"
                    :items [#:receipt-item{:account {:id :groceries}
                                           :quantity 100M
                                           :memo "weekly stuff"}]}
@@ -109,7 +115,8 @@
             :transaction/description "Kroger"
             :transaction/items [#:transaction-item{:action :credit
                                                    :account {:id :checking}
-                                                   :quantity 100M}
+                                                   :quantity 100M
+                                                   :memo "cash back"}
                                 #:transaction-item{:action :debit
                                                    :account {:id :groceries}
                                                    :quantity 100M


### PR DESCRIPTION
## Summary
- Add `:receipt/payment-memo` to the receipt data model (`clj_money.receipts`), threading it through `->transaction` and `<-transaction` alongside the existing `:receipt/payment-account`.
- Add a "Payment Memo" text field to the Receipts view form, next to Payment Method, following the same pattern used for expense line-item memos.

Trello card: https://trello.com/c/kxsU52Hl/324-payment-method-memo-in-receipt-entry

## Test plan
- [x] `lein test` — full suite passes (979 tests, 0 failures)
- [x] `lein cloverage` scoped to `clj-money.receipts` — 100% line coverage
- [x] `clj-kondo --lint` — no errors/warnings on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJxoKobBGHLt2NWseMZDov