### PR TITLE
feat: transaction search

### DIFF
--- a/src/clj_money/api/transactions.clj
+++ b/src/clj_money/api/transactions.clj
@@ -35,7 +35,6 @@
       (update-in-if [:created-at] unserialize-date)
       (update-in-if [:quantity] bigdec)
       (update-in-if [:account-id] #(hash-map :id (unserialize-id %)))
-      (update-in-if [:description] #(vector :contains %))
       (rename-keys {:transaction-date :transaction/transaction-date
                     :transaction-item-id :transaction-item/_self
                     :created-at :transaction/created-at

--- a/src/clj_money/api/transactions.clj
+++ b/src/clj_money/api/transactions.clj
@@ -17,7 +17,7 @@
             [clj-money.entities :as entities]
             [clj-money.entities.propagation :as prop]
             [clj-money.authorization.transactions]
-            [clj-money.entities.transactions]))
+            [clj-money.entities.transactions :as trns]))
 
 (defn- unserialize-date
   [x]
@@ -27,33 +27,31 @@
          (re-find #"^\d{4}-\d{2}-\d{2}$" x)) (unserialize-local-date x)
     :else x))
 
-(defn- throw-on-missing-constraint
-  [criteria]
-  (when-not ((some-fn :transaction/transaction-date
-                      :transaction/created-at
-                      :transaction-item/_self)
-             criteria)
-    (throw (ex-info "Invalid criteria" {:criteria criteria})))
-  criteria)
-
 (defn- extract-criteria
-  [{:keys [params authenticated]}]
+  [{:keys [params]}]
   (-> params
       comparatives/symbolize
       (update-in-if [:transaction-date] unserialize-date)
       (update-in-if [:created-at] unserialize-date)
+      (update-in-if [:quantity] bigdec)
+      (update-in-if [:account-id] #(hash-map :id (unserialize-id %)))
+      (update-in-if [:description] #(vector :contains %))
       (rename-keys {:transaction-date :transaction/transaction-date
                     :transaction-item-id :transaction-item/_self
                     :created-at :transaction/created-at
-                    :entity-id :transaction/entity})
+                    :entity-id :transaction/entity
+                    :description :transaction/description
+                    :quantity :transaction-item/quantity
+                    :account-id :transaction-item/account})
       (update-in-if [:transaction/entity] #(hash-map :id %))
       (update-in-if [:transaction-item/_self] #(hash-map :id %))
       (select-keys [:transaction/entity
                     :transaction/transaction-date
                     :transaction/created-at
-                    :transaction-item/_self])
-      throw-on-missing-constraint
-      (+scope :transaction authenticated)))
+                    :transaction/description
+                    :transaction-item/_self
+                    :transaction-item/quantity
+                    :transaction-item/account])))
 
 (defn- extract-options
   [{:keys [params]}]
@@ -61,10 +59,20 @@
       (select-keys [:include-items])
       (rename-keys {:include-items :include-items?})))
 
+(def ^:private search-keys
+  #{:transaction/description
+    :transaction-item/quantity
+    :transaction-item/account})
+
 (defn- index
-  [req]
-  (api/response
-   (entities/select (extract-criteria req) (extract-options req))))
+  [{:keys [authenticated] :as req}]
+  (let [criteria (extract-criteria req)
+        search? (some criteria search-keys)
+        scoped (+scope criteria :transaction authenticated)]
+    (api/response
+     (if search?
+       (trns/search scoped)
+       (entities/select scoped (extract-options req))))))
 
 (defn- find-and-auth
   [{:keys [path-params authenticated]} action]

--- a/src/clj_money/api/transactions.cljs
+++ b/src/clj_money/api/transactions.cljs
@@ -18,9 +18,6 @@
 
 (defn select
   [criteria & {:as opts}]
-  {:pre [((some-fn :transaction/transaction-date
-                   :transaction/created-at)
-          criteria)]}
   (api/get
     (api/path :entities
               @current-entity
@@ -28,7 +25,12 @@
     (-> criteria
         (update-in-if [:transaction/transaction-date] serialize-date)
         (update-in-if [:transaction/created-at] serialize-date)
-        (rename-keys {:transaction/transaction-date :transaction-date})
+        (update-in-if [:transaction-item/account] :id)
+        (rename-keys {:transaction/transaction-date :transaction-date
+                      :transaction/created-at :created-at
+                      :transaction/description :description
+                      :transaction-item/quantity :quantity
+                      :transaction-item/account :account-id})
         comparatives/nominalize)
     (add-error-handler opts "Unable to retrieve the transactions: %s")))
 

--- a/src/clj_money/core.cljs
+++ b/src/clj_money/core.cljs
@@ -25,6 +25,7 @@
             [clj-money.views.commodities]
             [clj-money.views.accounts]
             [clj-money.views.transactions]
+            [clj-money.views.transaction-search]
             [clj-money.views.users]
             [clj-money.views.invitations]
             [clj-money.views.budgets]
@@ -62,6 +63,8 @@
     :tool-tip "Click here to enter receipts"}
    {:id :reports
     :tool-tip "Click here to view reports"}
+   {:id :search
+    :tool-tip "Click here to search transactions"}
    {:id :scheduled
     :tool-tip "Click here to manage schedule transactions"}
    {:id :users

--- a/src/clj_money/db/datomic.clj
+++ b/src/clj_money/db/datomic.clj
@@ -112,7 +112,7 @@
                                 :nil-replacements (->java-dates nil-replacements)
                                 :datalog/hints (:datalog/hints opts))
         (dtl/apply-options (dissoc opts :order-by :sort))
-        (queries/apply-select opts)
+        (queries/apply-select (assoc opts :target m-type))
         (ensure-bounding-where-clause m-type)
         rearrange-query)))
 

--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -1,6 +1,7 @@
 (ns clj-money.entities.transactions
   (:require [clojure.spec.alpha :as s]
             [clojure.core.async :as a]
+            [clojure.string :as string]
             [clojure.tools.logging :as log]
             [clojure.pprint :refer [pprint]]
             [clojure.walk :refer [postwalk]]
@@ -231,22 +232,52 @@
                            [:transaction-item/index :desc]]
                     :select-also [:transaction/transaction-date]}))
 
+(def ^:private search-result-limit 100)
+
+(defn- matches-description?
+  [description]
+  (let [needle (string/lower-case description)]
+    (fn [trx]
+      (string/includes? (string/lower-case (:transaction/description trx))
+                        needle))))
+
+(defn- find-description
+  "Locates a :transaction/description value in criteria that may be a plain
+  map or a stowaway conjunction, e.g. [:and {...} {...}]."
+  [criteria]
+  (cond
+    (map? criteria) (:transaction/description criteria)
+    (vector? criteria) (some find-description (rest criteria))))
+
+(defn- strip-description
+  "Removes :transaction/description from criteria that may be a plain map or
+  a stowaway conjunction, preserving the overall shape."
+  [criteria]
+  (cond
+    (map? criteria) (dissoc criteria :transaction/description)
+    (vector? criteria) (into [(first criteria)] (map strip-description (rest criteria)))
+    :else criteria))
+
 (defn search
   "Returns transactions matching the given criteria, which may combine
-  :transaction/* attributes (entity, transaction-date, description, etc.)
-  with :transaction-item/* attributes (quantity, account) that must match
-  on the same item. Callers are responsible for shaping criteria values
-  (e.g. wrapping a partial description match in [:contains ...])."
+  :transaction/* attributes (entity, transaction-date, etc.) with
+  :transaction-item/* attributes (quantity, account) that must match on the
+  same item. :transaction/description, if present, is matched as a
+  case-insensitive partial match, applied after the underlying query since
+  partial-text matching isn't uniformly supported by the storage backends."
   [criteria]
-  (let [trx-ids (->> (entities/select (util/entity-type criteria :transaction-item)
+  (let [description (find-description criteria)
+        db-criteria (strip-description criteria)
+        trx-ids (->> (entities/select (util/entity-type db-criteria :transaction-item)
                                       {:limit 500
                                        :select-also [:transaction-item/transaction]})
                      (map (comp :id :transaction-item/transaction))
                      set)]
     (when (seq trx-ids)
-      (entities/select (util/entity-type {:id [:in trx-ids]} :transaction)
-                       {:sort [[:transaction/transaction-date :desc]]
-                        :limit 100}))))
+      (cond->> (entities/select (util/entity-type {:id [:in trx-ids]} :transaction)
+                                {:sort [[:transaction/transaction-date :desc]]
+                                 :limit search-result-limit})
+        description (filter (matches-description? description))))))
 
 (defn- last-transaction-item-before
   [account date]

--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -232,6 +232,23 @@
                            [:transaction-item/index :desc]]
                     :select-also [:transaction/transaction-date]}))
 
+(defn search
+  "Returns transactions matching the given criteria, which may combine
+  :transaction/* attributes (entity, transaction-date, description, etc.)
+  with :transaction-item/* attributes (quantity, account) that must match
+  on the same item. Callers are responsible for shaping criteria values
+  (e.g. wrapping a partial description match in [:contains ...])."
+  [criteria]
+  (let [trx-ids (->> (entities/select (util/entity-type criteria :transaction-item)
+                                      {:limit 500
+                                       :select-also [:transaction-item/transaction]})
+                     (map (comp :id :transaction-item/transaction))
+                     set)]
+    (when (seq trx-ids)
+      (entities/select (util/entity-type {:id [:in trx-ids]} :transaction)
+                       {:sort [[:transaction/transaction-date :desc]]
+                        :limit 100}))))
+
 (defn- last-transaction-item-before
   [account date]
   (entities/find-by

--- a/src/clj_money/entities/transactions.clj
+++ b/src/clj_money/entities/transactions.clj
@@ -232,7 +232,8 @@
                            [:transaction-item/index :desc]]
                     :select-also [:transaction/transaction-date]}))
 
-(def ^:private search-result-limit 100)
+(def ^:dynamic *search-result-limit* 100)
+(def ^:dynamic *item-scan-limit* 500)
 
 (defn- matches-description?
   [description]
@@ -258,6 +259,44 @@
     (vector? criteria) (into [(first criteria)] (map strip-description (rest criteria)))
     :else criteria))
 
+(defn- has-item-criteria?
+  "True if criteria (a plain map or a stowaway conjunction) constrains
+  :transaction-item/* attributes, meaning the search must be scoped through
+  transaction items rather than queried directly against transactions."
+  [criteria]
+  (cond
+    (map? criteria) (boolean (some criteria [:transaction-item/quantity
+                                             :transaction-item/account]))
+    (vector? criteria) (boolean (some has-item-criteria? (rest criteria)))))
+
+(defn- search-by-item
+  "Finds transactions by joining through transaction items, so that
+  :transaction-item/* criteria (quantity, account) can be combined with
+  :transaction/* criteria. The item scan is sorted by transaction date, most
+  recent first, so that if *item-scan-limit* is reached, the items dropped
+  are the oldest, not an arbitrary subset."
+  [criteria]
+  (let [trx-ids (->> (entities/select (util/entity-type criteria :transaction-item)
+                                      {:sort [[:transaction/transaction-date :desc]]
+                                       :select-also [:transaction/transaction-date
+                                                     :transaction-item/transaction]
+                                       :limit *item-scan-limit*})
+                     (map (comp :id :transaction-item/transaction))
+                     set)]
+    (when (seq trx-ids)
+      (entities/select (util/entity-type {:id [:in trx-ids]} :transaction)
+                       {:sort [[:transaction/transaction-date :desc]]
+                        :limit *search-result-limit*}))))
+
+(defn- search-by-transaction
+  "Finds transactions directly, for criteria with no :transaction-item/*
+  constraints, avoiding an unnecessary (and lossy, once *item-scan-limit* is
+  reached) join through transaction items."
+  [criteria]
+  (entities/select (util/entity-type criteria :transaction)
+                   {:sort [[:transaction/transaction-date :desc]]
+                    :limit *search-result-limit*}))
+
 (defn search
   "Returns transactions matching the given criteria, which may combine
   :transaction/* attributes (entity, transaction-date, etc.) with
@@ -268,16 +307,11 @@
   [criteria]
   (let [description (find-description criteria)
         db-criteria (strip-description criteria)
-        trx-ids (->> (entities/select (util/entity-type db-criteria :transaction-item)
-                                      {:limit 500
-                                       :select-also [:transaction-item/transaction]})
-                     (map (comp :id :transaction-item/transaction))
-                     set)]
-    (when (seq trx-ids)
-      (cond->> (entities/select (util/entity-type {:id [:in trx-ids]} :transaction)
-                                {:sort [[:transaction/transaction-date :desc]]
-                                 :limit search-result-limit})
-        description (filter (matches-description? description))))))
+        trxs (if (has-item-criteria? db-criteria)
+               (search-by-item db-criteria)
+               (search-by-transaction db-criteria))]
+    (cond->> trxs
+      description (filter (matches-description? description)))))
 
 (defn- last-transaction-item-before
   [account date]

--- a/src/clj_money/views/scheduled.cljs
+++ b/src/clj_money/views/scheduled.cljs
@@ -3,7 +3,6 @@
             [clojure.string :as string]
             [cljs-time.core :as t]
             [secretary.core :as secretary :include-macros true]
-            [accountant.core :as accountant]
             [reagent.core :as r]
             [reagent.ratom :refer [make-reaction]]
             [camel-snake-kebab.core :as csk]
@@ -32,6 +31,7 @@
             [clj-money.cached-accounts :as cached-accts]
             [clj-money.scheduled-transactions :refer [next-transaction-date
                                                       pending? ]]
+            [clj-money.views.transactions :refer [navigate-to-transaction]]
             [clj-money.api.scheduled-transactions :as sched-trans]))
 
 (defn- map-next-occurrence
@@ -408,20 +408,12 @@
                                         :on-click #(swap! page-state dissoc :selected)}
         (icon-with-text :x-circle "Cancel")]])))
 
-(defn- open-transaction
-  [trx]
-  (let [item (first (:transaction/items trx))
-        account (get-in @accounts-by-id [(get-in item [:transaction-item/account :id])])]
-    (swap! app-state assoc :pending-transaction-item {:item item
-                                                       :account account})
-    (accountant/navigate! "/accounts")))
-
 (defn- created-row
   [{:transaction/keys [transaction-date description value] :as trx}]
   ^{:key (str "created-transaction-row-" (:id trx))}
   [:tr {:style {:cursor "pointer"}
         :title "Click here to view this transaction."
-        :on-click #(open-transaction trx)}
+        :on-click #(navigate-to-transaction trx)}
    [:td (format-date transaction-date)]
    [:td description]
    [:td (format-decimal value)]])

--- a/src/clj_money/views/transaction_search.cljs
+++ b/src/clj_money/views/transaction_search.cljs
@@ -1,0 +1,100 @@
+(ns clj-money.views.transaction-search
+  (:require [clojure.string :as string]
+            [secretary.core :as secretary :include-macros true]
+            [reagent.core :as r]
+            [reagent.format :refer [currency-format]]
+            [dgknght.app-lib.web :refer [format-date]]
+            [dgknght.app-lib.forms :as forms]
+            [clj-money.state :refer [app-state
+                                     accounts
+                                     accounts-by-id
+                                     +busy
+                                     -busy]]
+            [clj-money.accounts :refer [find-by-path]]
+            [clj-money.views.transactions :refer [navigate-to-transaction]]
+            [clj-money.api.transactions :as transactions]))
+
+(defn- ->criteria
+  [{:keys [description transaction-date quantity account]}]
+  (cond-> {}
+    (seq description)  (assoc :transaction/description description)
+    transaction-date    (assoc :transaction/transaction-date transaction-date)
+    quantity            (assoc :transaction-item/quantity quantity)
+    (:id account)       (assoc :transaction-item/account account)))
+
+(defn- search
+  [page-state]
+  (let [criteria (->criteria @(r/cursor page-state [:filters]))]
+    (when (seq criteria)
+      (+busy)
+      (transactions/select criteria
+                           :callback -busy
+                           :on-success #(swap! page-state assoc
+                                               :results %
+                                               :searched? true)))))
+
+(defn- result-row
+  [{:transaction/keys [transaction-date description value] :as trx} filters]
+  ^{:key (str "search-result-" (:id trx))}
+  [:tr {:style {:cursor "pointer"}
+        :title "Click here to view this transaction."
+        :on-click #(navigate-to-transaction trx (get-in filters [:account :id]))}
+   [:td (format-date transaction-date)]
+   [:td description]
+   [:td.text-end (currency-format value)]])
+
+(defn- results-table
+  [page-state]
+  (let [results (r/cursor page-state [:results])
+        searched? (r/cursor page-state [:searched?])
+        filters (r/cursor page-state [:filters])]
+    (fn []
+      (when @searched?
+        (if (seq @results)
+          [:table.table.table-hover
+           [:thead
+            [:tr
+             [:th "Date"]
+             [:th "Description"]
+             [:th.text-end "Amount"]]]
+           [:tbody
+            (doall (map #(result-row % @filters) @results))]]
+          [:div.alert.alert-info "No transactions matched the specified criteria."])))))
+
+(defn- search-form
+  [page-state]
+  (let [filters (r/cursor page-state [:filters])]
+    (fn []
+      [:form {:no-validate true
+              :on-submit (fn [e]
+                           (.preventDefault e)
+                           (search page-state))}
+       [forms/text-field filters [:description] {:caption "Description"}]
+       [forms/date-field filters [:transaction-date] {:caption "Date"}]
+       [forms/decimal-field filters [:quantity] {:caption "Amount"
+                                                 :fraction-digits 2}]
+       [forms/typeahead-field
+        filters
+        [:account :id]
+        {:caption "Account"
+         :search-fn (fn [input callback]
+                      (callback (find-by-path input @accounts)))
+         :caption-fn #(string/join "/" (:account/path %))
+         :value-fn :id
+         :find-fn (fn [id callback]
+                    (callback (@accounts-by-id id)))}]
+       [:button.btn.btn-primary {:type :submit
+                                 :title "Click here to search for transactions matching the specified criteria"}
+        "Search"]])))
+
+(defn- index []
+  (let [page-state (r/atom {:filters {}})]
+    (fn []
+      [:div.mt-3
+       [:h1 "Transaction Search"]
+       [search-form page-state]
+       [:div.mt-3
+        [results-table page-state]]])))
+
+(secretary/defroute "/search" []
+  (swap! app-state assoc :page #'index :active-nav :search))

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -3,6 +3,7 @@
             [clojure.zip :as zip]
             [cljs.core.async :as a :refer [<! >! go go-loop]]
             [cljs-time.core :as t]
+            [accountant.core :as accountant]
             [reagent.core :as r]
             [reagent.format :refer [currency-format]]
             [reagent.ratom :refer [make-reaction]]
@@ -22,6 +23,7 @@
             [clj-money.icons :refer [icon]]
             [clj-money.state :refer [accounts
                                      accounts-by-id
+                                     app-state
                                      +busy
                                      -busy]]
             [clj-money.util :as util :refer [id=]]
@@ -77,6 +79,21 @@
     :on-success (fn [trx]
                   (swap! page-state assoc :transaction trx)
                   (set-focus "transaction-date"))))
+
+(defn navigate-to-transaction
+  "Navigates to the Accounts view and opens the given transaction for
+  editing. When preferred-account-id is given and one of the transaction's
+  items references it, that item is used; otherwise the first item is used."
+  ([trx] (navigate-to-transaction trx nil))
+  ([trx preferred-account-id]
+   (let [item (or (->> (:transaction/items trx)
+                       (filter #(= preferred-account-id (get-in % [:transaction-item/account :id])))
+                       first)
+                  (first (:transaction/items trx)))
+         account (get-in @accounts-by-id [(get-in item [:transaction-item/account :id])])]
+     (swap! app-state assoc :pending-transaction-item {:item item
+                                                        :account account})
+     (accountant/navigate! "/accounts"))))
 
 (defn- polarize-quantities
   [account]

--- a/test/clj_money/api/transactions_test.clj
+++ b/test/clj_money/api/transactions_test.clj
@@ -119,6 +119,23 @@
   (with-context existing-context
     (assert-blocked-list (get-a-list "jane@doe.com"))))
 
+(deftest a-user-can-search-transactions-by-description-with-no-date-specified
+  (with-context existing-context
+    (assert-successful-list (get-a-list "john@doe.com" :query {:description "pay"}))))
+
+(deftest a-user-can-search-transactions-by-quantity
+  (with-context existing-context
+    (assert-successful-list (get-a-list "john@doe.com" :query {:quantity "1000"}))))
+
+(deftest a-user-can-search-transactions-by-account
+  (with-context existing-context
+    (assert-successful-list
+      (get-a-list "john@doe.com" :query {:account-id (:id (find-account "Checking"))}))))
+
+(deftest a-user-cannot-search-transactions-in-anothers-entity
+  (with-context existing-context
+    (assert-blocked-list (get-a-list "jane@doe.com" :query {:description "pay"}))))
+
 (defn- get-a-list-by-item
   [email]
   (let [item (find-transaction-item [(t/local-date 2016 2 1) 1000M "Checking"])]

--- a/test/clj_money/entities/transactions_test.clj
+++ b/test/clj_money/entities/transactions_test.clj
@@ -502,6 +502,71 @@
                (:transaction/transaction-date (entities/find result)))
             "The updated transaction can be retrieved")))))
 
+(def search-fn-context
+  (conj base-context
+        #:transaction{:transaction-date (t/local-date 2020 1 1)
+                      :entity "Personal"
+                      :description "Paycheck"
+                      :debit-account "Checking"
+                      :credit-account "Salary"
+                      :quantity 1000M}
+        #:transaction{:transaction-date (t/local-date 2020 1 2)
+                      :entity "Personal"
+                      :description "Kroger"
+                      :debit-account "Groceries"
+                      :credit-account "Checking"
+                      :quantity 200M}
+        #:transaction{:transaction-date (t/local-date 2020 1 3)
+                      :entity "Personal"
+                      :description "Kroger returned item"
+                      :debit-account "Checking"
+                      :credit-account "Groceries"
+                      :quantity 50M}))
+
+(dbtest search-transactions-by-description
+  (with-context search-fn-context
+    (let [entity (find-entity "Personal")]
+      (is (seq-of-maps-like? [{:transaction/description "Kroger returned item"}
+                              {:transaction/description "Kroger"}]
+                             (transactions/search #:transaction{:entity (util/->entity-ref entity)
+                                                                :description [:contains "kroger"]}))
+          "A case-insensitive, partial match on description is applied, most recent first"))))
+
+(dbtest search-transactions-by-date
+  (with-context search-fn-context
+    (let [entity (find-entity "Personal")]
+      (is (seq-of-maps-like? [{:transaction/description "Paycheck"}]
+                             (transactions/search #:transaction{:entity (util/->entity-ref entity)
+                                                                :transaction-date [:= (t/local-date 2020 1 1)]}))
+          "Only the transaction on the specified date is returned"))))
+
+(dbtest search-transactions-by-amount
+  (with-context search-fn-context
+    (let [entity (find-entity "Personal")]
+      (is (seq-of-maps-like? [{:transaction/description "Kroger returned item"}]
+                             (transactions/search {:transaction/entity (util/->entity-ref entity)
+                                                   :transaction-item/quantity [:= 50M]}))
+          "Only the transaction with an item matching the specified quantity is returned"))))
+
+(dbtest search-transactions-by-account
+  (with-context search-fn-context
+    (let [entity (find-entity "Personal")
+          salary (find-account "Salary")]
+      (is (seq-of-maps-like? [{:transaction/description "Paycheck"}]
+                             (transactions/search {:transaction/entity (util/->entity-ref entity)
+                                                   :transaction-item/account (util/->entity-ref salary)}))
+          "Only the transaction with an item referencing the specified account is returned"))))
+
+(dbtest search-transactions-by-a-combination-of-filters
+  (with-context search-fn-context
+    (let [entity (find-entity "Personal")
+          checking (find-account "Checking")]
+      (is (seq-of-maps-like? [{:transaction/description "Kroger"}]
+                             (transactions/search {:transaction/entity (util/->entity-ref entity)
+                                                   :transaction-item/account (util/->entity-ref checking)
+                                                   :transaction-item/quantity [:= 200M]}))
+          "Only transactions matching all of the specified filters are returned"))))
+
 (def short-circuit-context
   (conj base-context
         #:transaction{:transaction-date (t/local-date 2016 3 2)

--- a/test/clj_money/entities/transactions_test.clj
+++ b/test/clj_money/entities/transactions_test.clj
@@ -532,6 +532,17 @@
                                                                 :description "kroger"}))
           "A case-insensitive, partial match on description is applied, most recent first"))))
 
+(dbtest search-transactions-by-description-does-not-miss-matches-past-the-item-scan-limit
+  (with-context search-fn-context
+    (let [entity (find-entity "Personal")]
+      (binding [transactions/*item-scan-limit* 1]
+        (is (seq-of-maps-like? [{:transaction/description "Kroger returned item"}
+                                {:transaction/description "Kroger"}]
+                               (transactions/search #:transaction{:entity (util/->entity-ref entity)
+                                                                  :description "kroger"}))
+            "A description-only search is not bounded by the item scan limit, since it
+            queries transactions directly instead of joining through items")))))
+
 (dbtest search-transactions-by-date
   (with-context search-fn-context
     (let [entity (find-entity "Personal")]

--- a/test/clj_money/entities/transactions_test.clj
+++ b/test/clj_money/entities/transactions_test.clj
@@ -529,7 +529,7 @@
       (is (seq-of-maps-like? [{:transaction/description "Kroger returned item"}
                               {:transaction/description "Kroger"}]
                              (transactions/search #:transaction{:entity (util/->entity-ref entity)
-                                                                :description [:contains "kroger"]}))
+                                                                :description "kroger"}))
           "A case-insensitive, partial match on description is applied, most recent first"))))
 
 (dbtest search-transactions-by-date


### PR DESCRIPTION
## Summary
- Add a Transaction Search page (`/search`) letting a user search transactions by any combination of description (partial match), date (exact), amount (exact), and account (matches if any item references it).
- Add a nav item linking to the search page.
- Add `clj-money.entities.transactions/search`, joining through transaction items so item-level criteria (quantity, account) can combine with transaction-level criteria (entity, date). Partial description matching is applied as a case-insensitive substring filter after the query, since partial-text predicates aren't uniformly supported across the SQL and Datomic backends.
- Wire the `/api/transactions` index endpoint to route to the new search path when description/quantity/account criteria are present.

## Test plan
- [x] `lein test :only clj-money.entities.transactions-test` — passes on both `:sql` and `:datomic-peer` backends
- [x] `lein test :only clj-money.api.transactions-test` — passes
- [x] `lein test` (full suite) — 993 tests, 0 failures
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [ ] Manual UI verification of `/search` page (not performed this session — no login access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJxoKobBGHLt2NWseMZDov