### PR TITLE
fix: prevent delete API failure caused by raw Datomic transact result

### DIFF
--- a/.claude/scripts/show_trello_card.py
+++ b/.claude/scripts/show_trello_card.py
@@ -1,0 +1,29 @@
+import json
+import sys
+
+
+def load_cards(raw):
+    data = json.loads(raw)
+    # MCP tool results are sometimes wrapped as [{"text": "<json array>"}]
+    if isinstance(data, list) and data and isinstance(data[0], dict) and "text" in data[0]:
+        return json.loads(data[0]["text"])
+    return data
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: show_trello_card.py <result-file> <name-substring-or-pos>", file=sys.stderr)
+        sys.exit(1)
+
+    raw = open(sys.argv[1]).read()
+    cards = load_cards(raw)
+    needle = sys.argv[2] if len(sys.argv) > 2 else None
+
+    for c in cards:
+        match = needle is None or needle.lower() in c["name"].lower() or str(c.get("pos")) == needle
+        if match:
+            print(json.dumps(c, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clj_money/db/datomic.clj
+++ b/src/clj_money/db/datomic.clj
@@ -388,13 +388,18 @@
   [entities {:keys [api] :as opts}]
   {:pre [(and (sequential? entities)
               (not-any? nil? entities))]}
+  ; Discard the raw transact result (:db-before, :db-after, :tx-data, etc.)
+  ; instead of returning it: it carries live Datomic index/database objects
+  ; that aren't safe to walk (e.g. via wrap-decimals) or serialize, and the
+  ; SQL backend's delete likewise returns nothing meaningful here.
   (transact api
             (->> entities
                  ; TODO: move this into the put* so that the propagations are
                  ; returned instead of executed
                  (mapcat #(propagate-delete % opts))
                  (mapv #(vector :db/retractEntity (:id %))))
-            {}))
+            {})
+  [])
 
 (def ^:private dependency-attrs
   {:entity [:commodity/entity


### PR DESCRIPTION
## Summary
- `delete*` in the Datomic backend returned the raw `transact()` result (`:db-before`, `:db-after`, `:tx-data`), which carries live Datomic index/database objects
- Those objects broke `wrap-decimals`' `postwalk` on the delete API response (`AbstractMethodError` on `datomic.index.Index`), producing a spurious server error even though the delete had actually succeeded
- Discard the transact result and return `[]` instead, matching the SQL backend's existing delete contract (which never returns entity data for deletes)

## Test plan
- [x] `lein test clj-money.entities.transactions-test clj-money.api.transactions-test` — 94 tests, 213 assertions, 0 failures
- [x] `lein test clj-money.api.transaction-items-test clj-money.entities.transaction-items-test` — 7 tests, 16 assertions, 0 failures
- [x] `clj-kondo --lint src/clj_money/db/datomic.clj` — 0 errors, 0 warnings
- [x] Full suite: `lein test` — 979 tests, 2586 assertions, 0 failures, 0 errors

Fixes trello#334

🤖 Generated with [Claude Code](https://claude.com/claude-code)