### PR TITLE
fix: undo the trade when deleting a trade transaction

### DIFF
--- a/src/clj_money/api/transactions.clj
+++ b/src/clj_money/api/transactions.clj
@@ -16,6 +16,7 @@
             [clj-money.db.ref]
             [clj-money.entities :as entities]
             [clj-money.entities.propagation :as prop]
+            [clj-money.trading :as trading]
             [clj-money.authorization.transactions]
             [clj-money.entities.transactions]))
 
@@ -167,10 +168,28 @@
               api/update-response)
       api/not-found))
 
+(defn- trade-lot-items
+  "Returns the lot-items that tie a transaction to a trade (buy or sell),
+  or an empty vector for a transaction that isn't part of a trade.
+  A vector, because unbuy relies on indexed get-in access."
+  [trx]
+  (vec (entities/select (util/entity-type {:transaction/_self trx} :lot-item))))
+
+(defn- delete-transaction
+  "Deleting a transaction that is part of a trade must also undo the trade
+  (restoring lot and account balances), not just remove the transaction
+  record, otherwise the affected lot is left in an inconsistent state"
+  [trx]
+  (let [lot-items (trade-lot-items trx)]
+    (case (some-> lot-items first :lot-item/action)
+      :buy (trading/unbuy-and-propagate (assoc trx :transaction/lot-items lot-items))
+      :sell (trading/unsell-and-propagate trx)
+      (prop/delete-and-propagate trx))))
+
 (defn- delete
   [req]
   (or (some-> (find-and-auth req ::authorization/destroy)
-              prop/delete-and-propagate
+              delete-transaction
               api/response)
       api/not-found))
 

--- a/test/clj_money/api/transactions_test.clj
+++ b/test/clj_money/api/transactions_test.clj
@@ -392,3 +392,89 @@
 
 (deftest a-user-cannot-delete-a-transaction-in-anothers-entity
   (assert-blocked-delete (delete-a-transaction "jane@doe.com")))
+
+(def ^:private purchase-context
+  (conj context
+        #:commodity{:name "Apple, Inc."
+                    :entity "Personal"
+                    :symbol "AAPL"
+                    :type :stock
+                    :exchange :nasdaq}
+        #:account{:name "IRA"
+                  :entity "Personal"
+                  :type :asset}
+        #:transaction{:transaction-date (t/local-date 2016 1 1)
+                      :entity "Personal"
+                      :description "Opening balance"
+                      :debit-account "IRA"
+                      :credit-account "Salary"
+                      :quantity 2000M}
+        #:trade{:type :purchase
+                :entity "Personal"
+                :account "IRA"
+                :commodity "AAPL"
+                :date (t/local-date 2016 1 2)
+                :shares 100M
+                :value 1000M}))
+
+(def ^:private sale-context
+  (conj purchase-context
+        #:trade{:type :sale
+                :entity "Personal"
+                :account "IRA"
+                :commodity "AAPL"
+                :inventory-method :fifo
+                :date (t/local-date 2016 3 2)
+                :shares 25M
+                :value 375M}))
+
+(defn- delete-a-trade-transaction
+  [ctx date-and-desc]
+  (with-context ctx
+    (let [transaction (find-transaction date-and-desc)
+          ira (find-account "IRA")
+          response (-> (request :delete (path :api
+                                             :transactions
+                                             (:id transaction))
+                                :user (find-user "john@doe.com"))
+                       app)]
+      {:response response
+       :transaction (entities/find transaction)
+       :ira (entities/find ira)
+       :lot (entities/find-by {:lot/account ira})})))
+
+(deftest a-user-can-delete-a-purchase-transaction-and-undo-the-trade
+  (let [{:keys [response transaction ira lot]}
+        (delete-a-trade-transaction purchase-context
+                                    [(t/local-date 2016 1 2)
+                                     #"^Purchase 100\.000 shares of AAPL"])]
+    (is (http-success? response))
+    (is (nil? transaction)
+        "The transaction cannot be retrieved after delete")
+    (is (comparable? {:account/quantity 2000M} ira)
+        "The account balance is restored to before the purchase")
+    (is (nil? lot)
+        "The lot is removed")))
+
+(deftest a-user-can-delete-a-sale-transaction-and-undo-the-trade
+  (let [{:keys [response transaction ira lot]}
+        (delete-a-trade-transaction sale-context
+                                    [(t/local-date 2016 3 2)
+                                     #"^Sell 25\.000 shares of AAPL"])]
+    (is (http-success? response))
+    (is (nil? transaction)
+        "The transaction cannot be retrieved after delete")
+    (is (comparable? {:account/quantity 1000M} ira)
+        "The account balance is restored to before the sale")
+    (is (comparable? {:lot/shares-owned 100M} lot)
+        "The shares are restored to the lot")))
+
+(deftest a-user-cannot-delete-a-purchase-transaction-after-shares-are-sold
+  (let [{:keys [response transaction]}
+        (delete-a-trade-transaction sale-context
+                                    [(t/local-date 2016 1 2)
+                                     #"^Purchase 100\.000 shares of AAPL"])]
+    (is (not (<= 200 (:status response) 299))
+        "The delete is blocked because shares have already been sold from the lot")
+    (is transaction
+        "The transaction can still be retrieved after a blocked delete")))


### PR DESCRIPTION
## Summary
- Clicking delete on a transaction row that's part of a trade only ran a plain `entities/delete` + propagation; `clj-money.trading/unbuy` and `unsell` — which correctly reverse a purchase or sale, restoring lot/account balances and refusing to undo a purchase if shares have since been sold from the lot — were never wired to `DELETE /api/transactions/:id`
- The delete handler now looks up the lot-items tied to the transaction being deleted and routes to `unbuy-and-propagate`/`unsell-and-propagate` when found, falling back to the previous plain delete for non-trade transactions

## Test plan
- [x] New API tests in `clj_money.api.transactions-test`:
  - deleting a purchase transaction restores the account balance and removes the lot
  - deleting a sale transaction restores the account balance and the lot's shares-owned
  - deleting a purchase transaction is blocked once shares have been sold from its lot
- [x] `lein test clj-money.api.transactions-test` — 18 tests, 52 assertions, 0 failures
- [x] `lein test clj-money.trading-test clj-money.entities.transactions-test clj-money.api.transaction-items-test` — 113 tests, 252 assertions, 0 failures
- [x] `clj-kondo --lint src/clj_money/api/transactions.clj test/clj_money/api/transactions_test.clj` — 0 errors, 0 warnings
- [x] Full suite: `lein test` — 982 tests, 2596 assertions, 0 failures, 0 errors

Fixes trello#336

🤖 Generated with [Claude Code](https://claude.com/claude-code)