### PR TITLE
feat: add Caddy reverse proxy for local HTTPS

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+money.localhost {
+	reverse_proxy 127.0.0.1:3000
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,37 @@ Stop the client:
 :cljs/quit
 ```
 
+### Local HTTPS with Caddy (optional)
+
+A `Caddyfile` in the project root fronts the app with
+[Caddy](https://caddyserver.com/) as a local reverse proxy, so it's available
+at `https://money.localhost` with an automatically trusted certificate
+instead of the raw `http://lvh.me:3000` address. This is optional — it's a
+convenience for testing things that behave differently over HTTPS, not
+required for day-to-day development. `caddy` is pinned in `mise.toml`, so
+`mise install` picks it up along with the other project tools — no separate
+install step needed.
+
+Caddy binds to port 443, which on Linux requires elevated privileges. Rather
+than running Caddy itself as root, grant just that capability to the binary
+once:
+
+```bash
+mise run caddy-setcap
+```
+
+(This needs to be re-run any time the pinned `caddy` version in
+`mise.toml` changes, since the capability is tied to that specific binary.)
+
+With the app server running (`(start-server)`, above), start Caddy from the
+project root:
+
+```bash
+mise run caddy
+```
+
+Then browse to [https://money.localhost](https://money.localhost).
+
 ## Dependency Updates
 
 Dependencies are kept current via [Renovate](https://github.com/apps/renovate). It is configured in `renovate.json` to open weekly PRs (Monday mornings, America/Chicago) covering:

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@ java = "temurin-25.0.4+7.0.LTS"
 node = "24"
 lein = "2.11.2"
 clj-kondo = "2026.01.19"
+caddy = "2.11.4"
 
 [tasks.lint]
 description = "Lint Clojure source"
@@ -55,6 +56,14 @@ sass src/scss/site.scss resources/public/css/site.css
 [tasks.download-otel]
 description = "Download OpenTelemetry Java agent"
 run = "./scripts/download-otel"
+
+[tasks.caddy]
+description = "Run the Caddy reverse proxy (serves https://money.localhost)"
+run = "caddy run"
+
+[tasks.caddy-setcap]
+description = "Grant caddy permission to bind to port 443 without root (requires sudo once; re-run after the pinned caddy version changes)"
+run = "sudo setcap cap_net_bind_service=+ep $(mise which caddy)"
 
 [tasks.sql-setup]
 description = "Create SQL databases and run migrations (SQL strategy)"


### PR DESCRIPTION
## Summary
- Add a `Caddyfile` fronting the dev server so it's reachable at `https://money.localhost` with a trusted local certificate
- Pin `caddy` in `mise.toml` and add `caddy` / `caddy-setcap` tasks (mirrors the setup in clj-groceries)
- Document the optional HTTPS workflow in `docs/development.md`

## Test plan
- [x] `mise exec -- caddy validate --config Caddyfile` passes
- [x] `clj-kondo --lint src:test` passes with 0 errors/warnings
- [ ] Manually verify `mise run caddy-setcap` + `mise run caddy` serves the app at https://money.localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgRpbt48bhkS9r2GUxk97X