### PR TITLE
feat: reconcile a commodity account

### DIFF
--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -907,14 +907,15 @@
         transaction (r/cursor page-state [:transaction])
         trade (r/cursor page-state [:trade])
         attachments-item (r/cursor page-state [:attachments-item])
+        reconciliation (r/cursor page-state [:reconciliation])
         show? (make-reaction #(and @account
                                    (not @attachments-item)
-                                   (not (system-tagged? @account :tradable))
+                                   (or @reconciliation
+                                       (not (system-tagged? @account :tradable)))
                                    (not @transaction)
                                    (not @trade)))
         ctl-chan (r/cursor page-state [:ctl-chan])
         all-items-fetched? (r/cursor page-state [:all-items-fetched?])
-        reconciliation (r/cursor page-state [:reconciliation])
         hide (make-reaction #(or @trade
                                  (not @reconciliation)))]
     (fn []
@@ -1062,8 +1063,10 @@
   [page-state]
   (let [account (r/cursor page-state [:view-account])
         trade (r/cursor page-state [:trade])
+        reconciliation (r/cursor page-state [:reconciliation])
         show? (make-reaction #(and (system-tagged? @account :tradable)
-                                   (not @trade)))
+                                   (not @trade)
+                                   (not @reconciliation)))
         current-nav (r/atom :lots)]
     (fn []
       (when @show?
@@ -1087,6 +1090,12 @@
             {:title "Click here to buy or sell this commodity."
              :on-click #(new-trade page-state)}
             (icon-with-text :plus "Buy/Sell")]
+           [:button.btn.btn-secondary.ms-2
+            {:title "Click here to reconcile this account."
+             :on-click (fn []
+                         (trns/stop-item-loading page-state)
+                         (start-reconciliation page-state))}
+            (icon-with-text :list-check "Reconcile")]
            [:button.btn.btn-secondary.ms-2
             {:title "Click here to return the the account list."
              :on-click (unselect-account page-state)}

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -240,14 +240,13 @@
           :aria-expanded "false"}
          (icon :three-dots-vertical :size :small)]
         [:ul.dropdown-menu
-         (when (not (system-tagged? account :tradable))
-           [:li
-            [:a.dropdown-item
-             {:title "Click here to reconcile this account"
-              :href "#"
-              :on-click (reconcile-account account page-state)}
-             (icon :list-check :size :small)
-             [:span.ms-2 "Reconcile"]]])
+         [:li
+          [:a.dropdown-item
+           {:title "Click here to reconcile this account"
+            :href "#"
+            :on-click (reconcile-account account page-state)}
+           (icon :list-check :size :small)
+           [:span.ms-2 "Reconcile"]]]
          (when (system-tagged? account :trading)
            [:li
             [:a.dropdown-item

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -404,7 +404,8 @@
                        description]
     :transaction-item/keys [polarized-quantity
                             balance
-                            value]}
+                            value]
+    :reconciliation/keys [status]}
    page-state]
   (let [id (:id item)
         audit-history (get-in @page-state [:trx-item-audit-histories id])
@@ -421,14 +422,21 @@
         #(toggle-trx-item-audit! page-state item)]
        [:div.ms-auto (format-decimal polarized-quantity 4)]]]
      [:td.text-end (format-decimal balance 4)]
-     [:td.text-end (currency-format (or value polarized-quantity))]]))
+     [:td.text-end (currency-format (or value polarized-quantity))]
+     [:td.text-center.d-none.d-md-table-cell
+      (icon
+        (case status
+          :completed :check-square
+          :new       :dash-sqaure
+          :square)
+        :size :small)]]))
 
 (defn- lot-note-row
   [{:lot-note/keys [transaction-date memo] :as note}]
   ^{:key (str "note-" (:id note))}
   [:tr
    [:td.text-end (format-date transaction-date)]
-   [:td.text-muted.fst-italic {:col-span 4} memo]])
+   [:td.text-muted.fst-italic {:col-span 5} memo]])
 
 (defn fund-transactions-table
   [page-state]
@@ -449,7 +457,17 @@
     (trx-items/select (accounts/->criteria @account)
                       :post-xf (map (polarize-quantities @account))
                       :on-success (fn [items]
-                                    (swap! page-state assoc :items items)
+                                    (swap! page-state assoc :items
+                                           (map (fn [{:transaction-item/keys [reconciliation]
+                                                      :keys [id]
+                                                      :as item}]
+                                                  (assoc item
+                                                         :reconciliation/status
+                                                         (cond
+                                                           (nil? id) :new
+                                                           reconciliation :completed
+                                                           :else :unreconciled)))
+                                                items))
                                     (doseq [item items]
                                       (load-trx-item-audit! page-state item))))
     (fn []
@@ -460,12 +478,13 @@
          [:th "Description"]
          [:th.text-end "Qty."]
          [:th.text-end "Bal."]
-         [:th.text-end "Value"]]]
+         [:th.text-end "Value"]
+         [:th.text-center.d-none.d-md-table-cell "Rec."]]]
        [:tbody
         (cond
           (nil? @items)
           [:tr
-           [:td.text-center.fw-lighter {:col-span 5}
+           [:td.text-center.fw-lighter {:col-span 6}
             [:div.d-flex.justify-content-center.m2
              [:div.spinner-border {:role :status}
               [:span.visually-hidden "Loading"]]]]]
@@ -479,7 +498,7 @@
 
           :else
           [:tr [:td.text-center.fw-lighter
-                {:col-span 5}
+                {:col-span 6}
                 "No transaction for this commodity."]])]])))
 
 (defn- ensure-entry-state


### PR DESCRIPTION
## Summary
- Add a "Reconcile" button between "+ Buy/Sell" and "<- Back" on the commodity account view (lots/transactions), matching the position requested in Trello card #330.
- Reuse the existing reconciliation form and unreconciled-item checklist already used for regular accounts — the backend reconciliation model is account-agnostic (already handles share-quantity balances, e.g. for stock-split adjustments), so no server-side changes were needed.
- Hide the lots/transactions tabs while reconciling and show the item checklist instead, mirroring the regular-account reconciliation flow exactly.
- Add a "Rec." column to the commodity account's Transactions tab, showing the same reconciled/unreconciled/pending icon used in the regular account transaction item list.

## Test plan
- [x] `clj-kondo --lint src:test` passes with 0 errors/warnings
- [x] Manually verified in browser: opened a commodity account (Grayscale Bitcoin Mini), clicked "Reconcile", checked off the unreconciled item, entered a matching balance, confirmed Reconciled/New Balance/Difference computed correctly (0.0000 difference, Complete button enabled), then discarded without saving
- [x] Manually verified the Transactions tab now shows a "Rec." column with the unreconciled-item icon rendering correctly across multiple commodity accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgRpbt48bhkS9r2GUxk97X