### PR TITLE
feat: dividend entry improvements

### DIFF
--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -1270,6 +1270,8 @@
         reconciliation (r/cursor page-state [:reconciliation])
         selected (r/cursor page-state [:selected])
         transaction (r/cursor page-state [:transaction])
+        trade (r/cursor page-state [:trade])
+        dividend? (make-reaction #(:trade/dividend? @trade))
         allocation-account (r/cursor page-state [:allocation :account])
         bulk-select (r/cursor page-state [:bulk-edit :account-ids])
         hide-table? (make-reaction #(or @selected
@@ -1343,7 +1345,12 @@
            [recs/reconciliation-form page-state]])]
        [tradable-account-items page-state]
        [transaction-form page-state]
-       [trade-form page-state]
+       [:div.row
+        [:div {:class (if @dividend? "col-md-6" "col")}
+         [trade-form page-state]]
+        (when @dividend?
+          [:div.col-md-6
+           [trns/recent-transactions-table page-state]])]
        [atts/attachments-card page-state]
        [atts/attachment-form page-state]
        [trns/pending-attachment-form page-state]

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -684,14 +684,18 @@
   (set-focus "transaction-date"))
 
 (defn- new-dividend
-  [page-state]
-  (swap! page-state assoc
-         :trade #:trade{:entity @current-entity
-                        :dividend? true
-                        :action :buy
-                        :date (t/today)
-                        :account (:view-account @page-state)})
-  (set-focus "transaction-date"))
+  ([page-state]
+   (swap! page-state dissoc :dividend-repeat?)
+   (new-dividend page-state {}))
+  ([page-state {:keys [date dividend-account]}]
+   (swap! page-state assoc
+          :trade (cond-> #:trade{:entity @current-entity
+                                 :dividend? true
+                                 :action :buy
+                                 :date (or date (t/today))
+                                 :account (:view-account @page-state)}
+                   dividend-account (assoc :trade/dividend-account dividend-account)))
+   (set-focus "transaction-date")))
 
 (defn- create-trx-button
   [page-state]
@@ -800,12 +804,16 @@
   [page-state]
   (fn [result]
     (let [updated-account (push-transaction-date! (:view-account @page-state)
-                                                   (extract-trx-date result))]
+                                                   (extract-trx-date result))
+          {:trade/keys [dividend? date dividend-account]} (:trade @page-state)
+          repeat-dividend? (and dividend? (:dividend-repeat? @page-state))]
       (swap! page-state
              (fn [state]
                (-> state
                    (dissoc :transaction :trade)
-                   (assoc :view-account updated-account)))))
+                   (assoc :view-account updated-account))))
+      (when repeat-dividend?
+        (new-dividend page-state {:date date :dividend-account dividend-account})))
     (trns/reset-item-loading page-state)))
 
 (defn- expand-trx []

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -716,14 +716,19 @@
                     (callback (@commodities id)))
          :validations #{::v/required}}]
        (when @dividend?
-         [forms/typeahead-field
-          trade
-          [:trade/dividend-account]
-          {:search-fn (fn [input callback]
-                        (->> @accounts
-                             (find-by-path input)
-                             callback))
-           :caption-fn (comp (partial string/join "/") :account/path)
-           :find-fn (fn [{:keys [id]} callback]
-                      (callback (@accounts-by-id id)))
-           :validations #{::v/required}}])])))
+         [:<>
+          [forms/typeahead-field
+           trade
+           [:trade/dividend-account]
+           {:search-fn (fn [input callback]
+                         (->> @accounts
+                              (find-by-path input)
+                              callback))
+            :caption-fn (comp (partial string/join "/") :account/path)
+            :find-fn (fn [{:keys [id]} callback]
+                       (callback (@accounts-by-id id)))
+            :validations #{::v/required}}]
+          [forms/checkbox-field
+           page-state
+           [:dividend-repeat?]
+           {:caption "Save and add another"}]])])))

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -381,6 +381,61 @@
           :else
           [:tr [:td.text-center {:col-span 6} (bs/spinner {:size :small})]])]])))
 
+(defn- recent-transaction-row
+  [account page-state]
+  (fn [{:transaction/keys [transaction-date description]
+        :transaction-item/keys [polarized-quantity]
+        :as item}]
+    ^{:key (str "recent-trx-" (:id item))}
+    [:tr
+     [:td.text-end (format-date transaction-date)]
+     [:td description]
+     [:td.text-end (format-quantity polarized-quantity account)]
+     [:td.text-end
+      [:button.btn.btn-sm.btn-secondary
+       {:on-click #(edit-transaction item page-state)
+        :title "Click here to edit this transaction."}
+       (icon :pencil :size :small)]]]))
+
+(defn- recent-transaction-compare
+  "Sorts newest-first by transaction date, breaking ties on :id (which
+  increases monotonically with insertion) since many transactions can
+  share the same transaction date."
+  [{d1 :transaction/transaction-date id1 :id}
+   {d2 :transaction/transaction-date id2 :id}]
+  (cond
+    (date-compare d1 d2) 1
+    (date-compare d2 d1) -1
+    :else (compare id2 id1)))
+
+(defn recent-transactions-table
+  [page-state]
+  (let [items (r/cursor page-state [:items])
+        account (r/cursor page-state [:view-account])
+        recent (make-reaction #(->> @items
+                                    (sort recent-transaction-compare)
+                                    (take 5)))]
+    (fn []
+      [:<>
+       [:h3 "Recent Transactions"]
+       [:table.table.table-hover.table-striped
+        [:thead
+         [:tr
+          [:th.text-end "Date"]
+          [:th "Description"]
+          [:th.text-end "Amount"]
+          [:th (space)]]]
+        [:tbody
+         (cond
+           (seq @recent)
+           (doall (map (recent-transaction-row @account page-state) @recent))
+
+           @items
+           [:tr [:td.text-center.fw-lighter {:col-span 4} "No recent transactions"]]
+
+           :else
+           [:tr [:td.text-center {:col-span 4} (bs/spinner {:size :small})]])]]])))
+
 (defn- load-trx-item-audit!
   [page-state item]
   (audit/select item :transaction-item/quantity


### PR DESCRIPTION
## Summary
- Add a "Save and add another" checkbox to the reinvested-dividend form, mirroring the Receipts view's repeat-entry workflow (Trello #329).
- When checked, saving a dividend keeps the form open for the next entry instead of closing it.
- The date and dividend account from the just-saved transaction persist into the freshly reset form; shares, value, fee, and commodity are cleared for the new entry.
- The checkbox state itself persists across repeat saves within a session but resets whenever a fresh dividend entry is started from the "Dividend" menu item.
- Add a "Recent Transactions" table beside the dividend form (below it on small screens), also mirroring the Receipts view layout, so repeat entries are visible without leaving the page.

## Test plan
- [x] `clj-kondo --lint src:test` passes with 0 errors/warnings
- [x] Manually verified in browser against the Vanguard trading account: opened "Dividend" from the Add dropdown, checked "Save and add another", entered several dividends across multiple commodities — form reopened each time with date and dividend account pre-filled, shares/value/commodity blank
- [x] Verified the Recent Transactions table surfaces each newly-saved dividend at the top immediately after save. Initial version sorted by transaction date only, which failed to distinguish same-day repeat entries (a real bug caught during manual testing where the table appeared stuck showing stale entries even though the underlying transactions saved correctly); fixed by adding `:id` as a tie-breaker since it increases monotonically with insertion.