### PR TITLE
feat: indicate reconciled items in transaction edit form

### DIFF
--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -547,41 +547,49 @@
 
 (defn- item-input-row
   [item index item-count page-state]
-  ^{:key (str "item-form-" index)}
-  [:tr
-   [:td [forms/typeahead-input
-         item
-         [:transaction-item/account]
-         {:search-fn (fn [input callback]
-                       (callback (find-by-path input @accounts)))
-          :on-change #(ensure-entry-state page-state)
-          :caption-fn #(string/join "/" (:account/path %))
-          :find-fn (fn [{:keys [id]} callback]
-                     (callback (@accounts-by-id id)))
-          :html {:id (str "account-id-" index)
-                 :on-key-up #(item-navigate % item-count)}}]]
-   [:td [forms/text-input
-         item
-         [:transaction-item/memo]
-         {:on-change #(ensure-entry-state page-state)
-          :html {:on-key-up #(item-navigate % item-count)
-                 :id (str "memo-" index)}}]]
-   [:td [forms/decimal-input
-         item
-         [:transaction-item/credit-quantity]
-         {:fraction-digits 2
-          :on-accept #(ensure-entry-state page-state)
-          :html {:on-key-up #(item-navigate % item-count)
-                 :on-key-down #(when (arrow-key? %) (.preventDefault %))
-                 :id (str "credit-quantity-" index)}}]]
-   [:td [forms/decimal-input
-         item
-         [:transaction-item/debit-quantity]
-         {:fraction-digits 2
-          :on-accept #(ensure-entry-state page-state)
-          :html {:id (str "debit-quantity-" index)
-                 :on-key-up #(item-navigate % item-count)
-                 :on-key-down #(when (arrow-key? %) (.preventDefault %))}}]]])
+  (let [reconciled? (boolean (:transaction-item/reconciliation @item))]
+    ^{:key (str "item-form-" index)}
+    [:tr
+     [:td.text-center
+      (when reconciled?
+        [:span {:title "This item has been reconciled and cannot be changed."}
+         (icon :lock-fill :size :small)])]
+     [:td [forms/typeahead-input
+           item
+           [:transaction-item/account]
+           {:search-fn (fn [input callback]
+                         (callback (find-by-path input @accounts)))
+            :on-change #(ensure-entry-state page-state)
+            :caption-fn #(string/join "/" (:account/path %))
+            :find-fn (fn [{:keys [id]} callback]
+                       (callback (@accounts-by-id id)))
+            :html {:id (str "account-id-" index)
+                   :on-key-up #(item-navigate % item-count)
+                   :disabled reconciled?}}]]
+     [:td [forms/text-input
+           item
+           [:transaction-item/memo]
+           {:on-change #(ensure-entry-state page-state)
+            :html {:on-key-up #(item-navigate % item-count)
+                   :id (str "memo-" index)}}]]
+     [:td [forms/decimal-input
+           item
+           [:transaction-item/credit-quantity]
+           {:fraction-digits 2
+            :on-accept #(ensure-entry-state page-state)
+            :disabled-fn (constantly reconciled?)
+            :html {:on-key-up #(item-navigate % item-count)
+                   :on-key-down #(when (arrow-key? %) (.preventDefault %))
+                   :id (str "credit-quantity-" index)}}]]
+     [:td [forms/decimal-input
+           item
+           [:transaction-item/debit-quantity]
+           {:fraction-digits 2
+            :on-accept #(ensure-entry-state page-state)
+            :disabled-fn (constantly reconciled?)
+            :html {:id (str "debit-quantity-" index)
+                   :on-key-up #(item-navigate % item-count)
+                   :on-key-down #(when (arrow-key? %) (.preventDefault %))}}]]]))
 
 (defn full-transaction-form
   [page-state & {:keys [on-save]}]
@@ -612,6 +620,7 @@
         [:table.table
          [:thead
           [:tr
+           [:td (space)]
            [:td "Account"]
            [:td "Memo"]
            [:td "Credit Amount"]
@@ -624,7 +633,7 @@
                                    page-state)))]
          [:tfoot
           [:tr
-           [:td {:col-span 2} (special-char :nbsp)]
+           [:td {:col-span 3} (special-char :nbsp)]
            [:td.text-end (format-decimal @total-credits)]
            [:td.text-end.d-flex.flex-row-reverse.justify-content-between
             (format-decimal @total-debits)


### PR DESCRIPTION
## Summary
- Trello #333: when editing an existing transaction, visually indicate any item that is already reconciled, and prevent changing its account or quantity.
- `item-input-row` now checks `:transaction-item/reconciliation` (already present on items loaded via `entryfy`, unchanged by the edit pipeline) and:
  - shows a lock icon in a new leading column when the item is reconciled
  - disables the account typeahead field
  - disables the credit/debit quantity fields (via `:disabled-fn`, since `dgknght.app-lib.forms`'s decimal input overrides `:html {:disabled}` otherwise)
- Memo remains editable, since the card only calls out account, quantity, and action (credit/debit) as locked.
- Scope: this only covers `full-transaction-form` (the multi-item entry table used for any transaction with 2+ items, which is what `edit-transaction` uses for normal double-entry transactions). `simple-transaction-form` (used only for the alternate single-item "accountified" shorthand shape) doesn't currently carry `:transaction-item/reconciliation` through `accountify`, so it's out of scope here to avoid unrelated backend/transform changes.

## Test plan
- [x] `clj-kondo --lint src:test` passes with 0 errors/warnings
- [x] `lein test` — 982 tests, 2596 assertions, 0 failures/errors
- [x] Live browser verification was not performed this session (dev figwheel watcher was stalled); recommend a manual check before merge: edit a transaction with a reconciled item and confirm the lock icon appears and the account/quantity fields are disabled for that row.