### PR TITLE
feat: delete a transaction from the reconciliation view

### DIFF
--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -185,7 +185,16 @@
     (trx-items/delete
       transaction-item
       :callback -busy
-      :on-success #(reset-item-loading page-state))))
+      :on-success (fn []
+                    (if (:reconciliation @page-state)
+                      (do
+                        (swap! page-state
+                               update-in
+                               [:reconciliation :clj-money.views.reconciliations/item-selection]
+                               dissoc
+                               (:id transaction-item))
+                        (load-unreconciled-items page-state))
+                      (reset-item-loading page-state))))))
 
 (defn- post-item-row-drop
   [page-state item]
@@ -271,9 +280,13 @@
      (when-not @reconciliation
        [:td.text-end.d-none.d-md-table-cell (format-quantity balance
                                                              account)])
-     (when-not @reconciliation
-       [:td.d-flex.justify-content-end
-        [item-row-buttons item page-state]])]))
+     [:td.d-flex.justify-content-end
+      (if @reconciliation
+        [:button.btn.btn-danger.btn-sm
+         {:on-click #(delete-transaction item page-state)
+          :title "Click here to remove this transaction."}
+         (icon :x-circle :size :small)]
+        [item-row-buttons item page-state])]]))
 
 (defn- date-compare
   [d1 d2]
@@ -361,8 +374,7 @@
          [:th.text-center.d-none.d-md-table-cell "Rec."]
          (when-not @recon
            [:th.text-end.d-none.d-md-table-cell "Balance"])
-         (when-not @recon
-           [:th (space)])]]
+         [:th (space)]]]
        [:tbody
         (cond
           (seq @items)


### PR DESCRIPTION
## Summary
- Trello #323: while reconciling an account, a user can now delete an unreconciled transaction directly from the reconciliation checklist.
- Reuses the existing delete flow (`js/confirm` prompt) already used on the standard account transaction list.
- On success, the item's reconciliation selection state is cleared and the unreconciled-items list is reloaded (rather than falling back to the full, non-reconciliation item loader).
- Edit/attachment buttons remain hidden during reconciliation (out of scope — tracked separately as Trello #322).

## Test plan
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [x] `lein test` — 982 tests, 2596 assertions, 0 failures, 0 errors
- [ ] Live browser verification was not performed this session (dev figwheel watcher was stalled, same recurring issue as the prior PR); recommend a manual check before merge: start reconciling an account, delete one of the unreconciled items, confirm the prompt, and verify the item disappears from the list and reconciliation totals still compute correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)