### PR TITLE
feat: edit a transaction directly from reconciliation view

### DIFF
--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -835,7 +835,7 @@
           ->bilateral
           (accountify account)))))
 
-(defn- transaction-form-controls
+(defn- transaction-form
   [page-state]
   (let [transaction (r/cursor page-state [:transaction])]
     [:<>
@@ -871,7 +871,7 @@
         :title "Click here to cancel this transaction"}
        (icon-with-text :x "Cancel")]]]))
 
-(defn- transaction-form
+(defn- transaction-form-container
   [page-state]
   (let [transaction (r/cursor page-state [:transaction])
         reconciliation (r/cursor page-state [:reconciliation])]
@@ -884,9 +884,9 @@
             [:div.modal-dialog.modal-lg
              [:div.modal-content
               [:div.modal-body
-               [transaction-form-controls page-state]]]]]
+               [transaction-form page-state]]]]]
            [:div.modal-backdrop.show {:on-click #(swap! page-state dissoc :transaction)}]]
-          [transaction-form-controls page-state])))))
+          [transaction-form page-state])))))
 
 (defn- trade-form
   [page-state]
@@ -1369,7 +1369,7 @@
           [:div.col-lg-4
            [recs/reconciliation-form page-state]])]
        [tradable-account-items page-state]
-       [transaction-form page-state]
+       [transaction-form-container page-state]
        [:div.row
         [:div {:class (if @dividend? "col-md-6" "col")}
          [trade-form page-state]]

--- a/src/clj_money/views/accounts.cljs
+++ b/src/clj_money/views/accounts.cljs
@@ -813,7 +813,9 @@
                    (assoc :view-account updated-account))))
       (when repeat-dividend?
         (new-dividend page-state {:date date :dividend-account dividend-account})))
-    (trns/reset-item-loading page-state)))
+    (if (:reconciliation @page-state)
+      (trns/load-unreconciled-items page-state)
+      (trns/reset-item-loading page-state))))
 
 (defn- expand-trx []
   (fn [trx]
@@ -833,43 +835,58 @@
           ->bilateral
           (accountify account)))))
 
-(defn- transaction-form
+(defn- transaction-form-controls
   [page-state]
   (let [transaction (r/cursor page-state [:transaction])]
+    [:<>
+     [:div.d-flex.justify-content-between
+      [:h3 (if (:id @transaction)
+             "Edit Transaction"
+             "New Transaction")]
+      (cond
+        (accountified? @transaction)
+        [:button.btn.btn-secondary {:title "Click here to show full transaction details."
+                                    :on-click (fn [_]
+                                                (swap! transaction (expand-trx)))}
+         (icon :arrows-expand)]
+
+        (can-accountify? (->bilateral (unentryfy @transaction)))
+        [:button.btn.btn-secondary {:title "Click here to simplify transaction entry."
+                                    :on-click (fn [_]
+                                                (swap! transaction (collapse-trx page-state)))}
+         (icon :arrows-collapse)])]
+     [:div.mt-3
+      (let [f (if (accountified? @transaction)
+                trns/simple-transaction-form
+                trns/full-transaction-form)]
+        [f page-state :on-save (post-transaction-save page-state)])]
+     [:div
+      [:button.btn.btn-primary
+       {:type :submit
+        :form "transaction-form"
+        :title "Click here to save the transaction"}
+       (icon-with-text :check "Save")]
+      [:button.btn.btn-secondary.ms-2
+       {:on-click #(swap! page-state dissoc :transaction)
+        :title "Click here to cancel this transaction"}
+       (icon-with-text :x "Cancel")]]]))
+
+(defn- transaction-form
+  [page-state]
+  (let [transaction (r/cursor page-state [:transaction])
+        reconciliation (r/cursor page-state [:reconciliation])]
     (fn []
       (when @transaction
-        [:<>
-         [:div.d-flex.justify-content-between
-          [:h3 (if (:id @transaction)
-                 "Edit Transaction"
-                 "New Transaction")]
-          (cond
-            (accountified? @transaction)
-            [:button.btn.btn-secondary {:title "Click here to show full transaction details."
-                                        :on-click (fn [_]
-                                                    (swap! transaction (expand-trx)))}
-             (icon :arrows-expand)]
-
-            (can-accountify? (->bilateral (unentryfy @transaction)))
-            [:button.btn.btn-secondary {:title "Click here to simplify transaction entry."
-                                        :on-click (fn [_]
-                                                    (swap! transaction (collapse-trx page-state)))}
-             (icon :arrows-collapse)])]
-         [:div.mt-3
-          (let [f (if (accountified? @transaction)
-                    trns/simple-transaction-form
-                    trns/full-transaction-form)]
-            [f page-state :on-save (post-transaction-save page-state)])]
-         [:div
-          [:button.btn.btn-primary
-           {:type :submit
-            :form "transaction-form"
-            :title "Click here to save the transaction"}
-           (icon-with-text :check "Save")]
-          [:button.btn.btn-secondary.ms-2
-           {:on-click #(swap! page-state dissoc :transaction)
-            :title "Click here to cancel this transaction"}
-           (icon-with-text :x "Cancel")]]]))))
+        (if @reconciliation
+          [:<>
+           [:div.modal.show.d-block {:tab-index -1
+                                     :role :dialog}
+            [:div.modal-dialog.modal-lg
+             [:div.modal-content
+              [:div.modal-body
+               [transaction-form-controls page-state]]]]]
+           [:div.modal-backdrop.show {:on-click #(swap! page-state dissoc :transaction)}]]
+          [transaction-form-controls page-state])))))
 
 (defn- trade-form
   [page-state]
@@ -919,7 +936,7 @@
                                    (not @attachments-item)
                                    (or @reconciliation
                                        (not (system-tagged? @account :tradable)))
-                                   (not @transaction)
+                                   (or @reconciliation (not @transaction))
                                    (not @trade)))
         ctl-chan (r/cursor page-state [:ctl-chan])
         all-items-fetched? (r/cursor page-state [:all-items-fetched?])

--- a/src/clj_money/views/transactions.cljs
+++ b/src/clj_money/views/transactions.cljs
@@ -282,10 +282,15 @@
                                                              account)])
      [:td.d-flex.justify-content-end
       (if @reconciliation
-        [:button.btn.btn-danger.btn-sm
-         {:on-click #(delete-transaction item page-state)
-          :title "Click here to remove this transaction."}
-         (icon :x-circle :size :small)]
+        [:div.btn-group
+         [:button.btn.btn-secondary.btn-sm
+          {:on-click #(edit-transaction item page-state)
+           :title "Click here to edit this transaction."}
+          (icon :pencil :size :small)]
+         [:button.btn.btn-danger.btn-sm
+          {:on-click #(delete-transaction item page-state)
+           :title "Click here to remove this transaction."}
+          (icon :x-circle :size :small)]]
         [item-row-buttons item page-state])]]))
 
 (defn- date-compare


### PR DESCRIPTION
## Summary
- Trello #322: while reconciling an account, a user can now edit an unreconciled transaction directly from the reconciliation checklist, without leaving the reconciliation flow.
- Adds a pencil/edit button next to the existing delete button on each unreconciled item row (reuses the existing `edit-transaction` load path).
- The transaction form now renders as a Bootstrap modal (`.modal.show.d-block` + `.modal-backdrop.show`, same pattern already used for attachment captions) layered above the still-visible unreconciled-items list, rather than replacing the list as it does for the normal (non-reconciliation) account view.
- The item list stays visible behind the modal during reconciliation (`transaction-item-list`'s `show?` no longer hides on `:transaction` while `:reconciliation` is active).
- After a save made during reconciliation, the item list reloads via the unreconciled-items query (same fix applied for delete in #260) instead of falling back to the full account history loader.

## Test plan
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings
- [x] `lein test` — 982 tests, 2596 assertions, 0 failures, 0 errors
- [ ] Live browser verification was not performed this session (dev figwheel watcher was stalled again, same recurring issue as the prior two PRs); recommend a manual check before merge: start reconciling an account, edit one of the unreconciled items in the modal, save, and confirm the item list and reconciliation totals update correctly and the modal closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)