### PR TITLE
fix: honor include-children? when computing reconciliation previous balance

### DIFF
--- a/src/clj_money/api/reconciliations.clj
+++ b/src/clj_money/api/reconciliations.clj
@@ -94,9 +94,8 @@
 (defn- previous-balance
   [{:keys [params authenticated]}]
   (let [account {:id (:account-id params)}
-        include-children? (if (contains? params :include-children)
-                            (parse-bool (:include-children params))
-                            true)]
+        include-children? (when-let [i (:include-children params)]
+                            (parse-bool i))]
     (authorize {:reconciliation/account account} ::auth/show authenticated)
     (api/response {:reconciliation/balance (or (recs/previous-balance account include-children?) 0M)})))
 

--- a/src/clj_money/api/reconciliations.clj
+++ b/src/clj_money/api/reconciliations.clj
@@ -97,7 +97,7 @@
         include-children? (when-let [i (:include-children params)]
                             (parse-bool i))]
     (authorize {:reconciliation/account account} ::auth/show authenticated)
-    (api/response {:reconciliation/balance (or (recs/previous-balance account include-children?) 0M)})))
+    (api/response {:reconciliation/balance (or (recs/previous-balance account :include-children? include-children?) 0M)})))
 
 (defn- find-and-auth
   [{:keys [params authenticated]} action]

--- a/src/clj_money/api/reconciliations.clj
+++ b/src/clj_money/api/reconciliations.clj
@@ -2,7 +2,8 @@
   (:refer-clojure :exclude [update])
   (:require [clojure.set :refer [rename-keys]]
             [clojure.pprint :refer [pprint]]
-            [dgknght.app-lib.core :refer [update-in-if]]
+            [dgknght.app-lib.core :refer [update-in-if
+                                          parse-bool]]
             [clj-money.authorization
              :as auth
              :refer [+scope
@@ -92,9 +93,12 @@
 
 (defn- previous-balance
   [{:keys [params authenticated]}]
-  (let [account {:id (:account-id params)}]
+  (let [account {:id (:account-id params)}
+        include-children? (if (contains? params :include-children)
+                            (parse-bool (:include-children params))
+                            true)]
     (authorize {:reconciliation/account account} ::auth/show authenticated)
-    (api/response {:reconciliation/balance (or (recs/previous-balance account) 0M)})))
+    (api/response {:reconciliation/balance (or (recs/previous-balance account include-children?) 0M)})))
 
 (defn- find-and-auth
   [{:keys [params authenticated]} action]

--- a/src/clj_money/api/reconciliations.cljs
+++ b/src/clj_money/api/reconciliations.cljs
@@ -35,12 +35,12 @@
            (add-error-handler opts "Unable to retrieve the reconciliations: %s")))
 
 (defn previous-balance
-  [account & {:as opts}]
+  [account include-children? & {:as opts}]
   (api/get (api/path :accounts
                      account
                      :reconciliations
                      :previous-balance)
-           {}
+           {:include-children include-children?}
            (add-error-handler opts "Unable to retrieve the previous balance: %s")))
 
 (defn- simplify-items

--- a/src/clj_money/api/reconciliations.cljs
+++ b/src/clj_money/api/reconciliations.cljs
@@ -35,7 +35,7 @@
            (add-error-handler opts "Unable to retrieve the reconciliations: %s")))
 
 (defn previous-balance
-  [account include-children? & {:as opts}]
+  [account & {:as opts :keys [include-children?]}]
   (api/get (api/path :accounts
                      account
                      :reconciliations

--- a/src/clj_money/entities/reconciliations.clj
+++ b/src/clj_money/entities/reconciliations.clj
@@ -212,13 +212,12 @@
   include-children? is true, each not-yet-absorbed descendant's own last
   completed reconciliation balance. See compute-starting-balance for the full
   rule."
-  ([account] (previous-balance account true))
-  ([account include-children?]
-   (compute-starting-balance account
-                             (if include-children?
-                               (account+children account)
-                               [])
-                             nil)))
+  [account & {:keys [include-children?]}]
+  (compute-starting-balance account
+                            (if include-children?
+                              (account+children account)
+                              [])
+                            nil))
 
 (defn- polarize-item
   "Assoc :transaction-item/polarized-quantity to the item"

--- a/src/clj_money/entities/reconciliations.clj
+++ b/src/clj_money/entities/reconciliations.clj
@@ -208,11 +208,17 @@
 
 (defn previous-balance
   "Returns the balance to use as the starting point when reconciling the
-  given account: its own last completed reconciliation's balance, plus each
-  not-yet-absorbed descendant's own last completed reconciliation balance.
-  See compute-starting-balance for the full rule."
-  [account]
-  (compute-starting-balance account (account+children account) nil))
+  given account: its own last completed reconciliation's balance, plus, when
+  include-children? is true, each not-yet-absorbed descendant's own last
+  completed reconciliation balance. See compute-starting-balance for the full
+  rule."
+  ([account] (previous-balance account true))
+  ([account include-children?]
+   (compute-starting-balance account
+                             (if include-children?
+                               (account+children account)
+                               [])
+                             nil)))
 
 (defn- polarize-item
   "Assoc :transaction-item/polarized-quantity to the item"

--- a/src/clj_money/views/reconciliations.cljs
+++ b/src/clj_money/views/reconciliations.cljs
@@ -74,6 +74,7 @@
   [page-state]
   (+busy)
   (recs/previous-balance (:view-account @page-state)
+                         (:include-children? @page-state)
                          :callback -busy
                          :on-success (fn [r]
                                        (swap! page-state assoc
@@ -118,7 +119,9 @@
          [forms/checkbox-field
           page-state
           [:include-children?]
-          {:on-change #(trns/load-unreconciled-items page-state)}]]
+          {:on-change (fn []
+                        (trns/load-unreconciled-items page-state)
+                        (load-previous-balance page-state))}]]
         [:table.table
          [:tbody
           [:tr

--- a/src/clj_money/views/reconciliations.cljs
+++ b/src/clj_money/views/reconciliations.cljs
@@ -74,7 +74,7 @@
   [page-state]
   (+busy)
   (recs/previous-balance (:view-account @page-state)
-                         (:include-children? @page-state)
+                         :include-children? (:include-children? @page-state)
                          :callback -busy
                          :on-success (fn [r]
                                        (swap! page-state assoc

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -371,7 +371,9 @@
 
 (deftest a-user-can-get-the-previous-balance-for-a-parent-account
   (with-context child-recon-context
-    (let [{:as response :keys [parsed-body]} (get-previous-balance "john@doe.com")]
+    (let [{:as response :keys [parsed-body]} (get-previous-balance
+                                               "john@doe.com"
+                                               :include-children? true)]
       (is (http-success? response))
       (is (comparable? {:reconciliation/balance 100M}
                        (jsonize-decimals parsed-body))
@@ -379,7 +381,8 @@
 
 (deftest a-user-can-get-the-previous-balance-for-a-parent-account-excluding-children
   (with-context child-recon-context
-    (let [{:as response :keys [parsed-body]} (get-previous-balance "john@doe.com" :include-children? false)]
+    (let [{:as response :keys [parsed-body]} (get-previous-balance
+                                               "john@doe.com")]
       (is (http-success? response))
       (is (comparable? {:reconciliation/balance 0M}
                        (jsonize-decimals parsed-body))

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -9,6 +9,7 @@
             [dgknght.app-lib.web :refer [path]]
             [clj-money.entities.ref]
             [clj-money.util :as util]
+            [clj-money.api.util :refer [+query]]
             [clj-money.db.ref]
             [clj-money.test-helpers :refer [reset-db]]
             [clj-money.api.test-helper :refer [parse-body
@@ -355,23 +356,21 @@
 
 (defn- get-previous-balance
   [email & {:keys [include-children?]}]
-  (-> (request :get (cond-> (path :api
+  (-> (request :get (+query (path :api
                                   :accounts
                                   (:id (find-account "Savings"))
                                   :reconciliations
                                   :previous-balance)
-                      (some? include-children?) (-> uri
-                                                     (assoc :query
-                                                            (map->query-string
-                                                              {:include-children include-children?}))
-                                                     str))
+                            :include-children include-children?)
                :user (find-user email))
       app
       parse-body))
 
 (deftest a-user-can-get-the-previous-balance-for-a-parent-account
   (with-context child-recon-context
-    (let [{:as response :keys [parsed-body]} (get-previous-balance "john@doe.com")]
+    (let [{:as response :keys [parsed-body]} (get-previous-balance
+                                               "john@doe.com"
+                                               :include-children? true)]
       (is (http-success? response))
       (is (comparable? {:reconciliation/balance 100M}
                        (jsonize-decimals parsed-body))
@@ -379,7 +378,8 @@
 
 (deftest a-user-can-get-the-previous-balance-for-a-parent-account-excluding-children
   (with-context child-recon-context
-    (let [{:as response :keys [parsed-body]} (get-previous-balance "john@doe.com" :include-children? false)]
+    (let [{:as response :keys [parsed-body]} (get-previous-balance
+                                               "john@doe.com")]
       (is (http-success? response))
       (is (comparable? {:reconciliation/balance 0M}
                        (jsonize-decimals parsed-body))

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -3,6 +3,7 @@
             [clojure.pprint :refer [pprint]]
             [clojure.set :refer [rename-keys]]
             [java-time.api :as t]
+            [lambdaisland.uri :refer [map->query-string uri]]
             [dgknght.app-lib.test-assertions]
             [dgknght.app-lib.test]
             [dgknght.app-lib.web :refer [path]]
@@ -353,12 +354,17 @@
                          :items [[(t/local-date 2015 1 1) 100M]]}))
 
 (defn- get-previous-balance
-  [email]
-  (-> (request :get (path :api
-                          :accounts
-                          (:id (find-account "Savings"))
-                          :reconciliations
-                          :previous-balance)
+  [email & {:keys [include-children?]}]
+  (-> (request :get (cond-> (path :api
+                                  :accounts
+                                  (:id (find-account "Savings"))
+                                  :reconciliations
+                                  :previous-balance)
+                      (some? include-children?) (-> uri
+                                                     (assoc :query
+                                                            (map->query-string
+                                                              {:include-children include-children?}))
+                                                     str))
                :user (find-user email))
       app
       parse-body))
@@ -370,6 +376,14 @@
       (is (comparable? {:reconciliation/balance 100M}
                        (jsonize-decimals parsed-body))
           "The balance reflects the reconciled child account's own balance; the unreconciled sibling contributes nothing"))))
+
+(deftest a-user-can-get-the-previous-balance-for-a-parent-account-excluding-children
+  (with-context child-recon-context
+    (let [{:as response :keys [parsed-body]} (get-previous-balance "john@doe.com" :include-children? false)]
+      (is (http-success? response))
+      (is (comparable? {:reconciliation/balance 0M}
+                       (jsonize-decimals parsed-body))
+          "With include-children=false, the child account's reconciliation balance is ignored, even though Savings itself has no reconciliation of its own"))))
 
 (deftest a-user-cannot-get-the-previous-balance-for-anothers-account
   (with-context child-recon-context

--- a/test/clj_money/api/reconciliations_test.clj
+++ b/test/clj_money/api/reconciliations_test.clj
@@ -3,7 +3,6 @@
             [clojure.pprint :refer [pprint]]
             [clojure.set :refer [rename-keys]]
             [java-time.api :as t]
-            [lambdaisland.uri :refer [map->query-string uri]]
             [dgknght.app-lib.test-assertions]
             [dgknght.app-lib.test]
             [dgknght.app-lib.web :refer [path]]

--- a/test/clj_money/entities/reconciliations_test.clj
+++ b/test/clj_money/entities/reconciliations_test.clj
@@ -400,6 +400,23 @@
             (is (= 1600M (recs/previous-balance savings))
                 "The parent's own reconciliation balance is used once the child accounts' items are absorbed into it")))))))
 
+(dbtest get-the-previous-reconciliation-balance-excluding-children
+  (with-context previous-balance-ctx
+    (is (= 0M (recs/previous-balance (find-account "Savings") false))
+        "With include-children? false, the children's reconciliation balances are ignored, even though Savings itself has no reconciliation of its own")
+    (testing "and a reconciliation at the parent level"
+      (let [savings (find-account "Savings")
+            car-item (find-transaction-item [(t/local-date 2020 1 4) 300M (find-account "Car")])
+            reserve-item (find-transaction-item [(t/local-date 2020 1 4) 500M (find-account "Reserve")])]
+        (assert-created
+          #:reconciliation{:account savings
+                           :end-of-period (t/local-date 2021 2 28)
+                           :status :completed
+                           :balance 1600M
+                           :items [car-item reserve-item]})
+        (is (= 1600M (recs/previous-balance savings false))
+            "Savings' own reconciliation balance is still used when it exists")))))
+
 (def ^:private grandchild-context
   (conj parent-account-context
         #:account{:name "Reserve Sub"

--- a/test/clj_money/entities/reconciliations_test.clj
+++ b/test/clj_money/entities/reconciliations_test.clj
@@ -359,15 +359,17 @@
                          :items [[(t/local-date 2019 12 17)
                                   500M]]}))
 
-(dbtest get-the-previous-reconciliation-balance
+(dbtest get-the-previous-reconciliation-balance-including-children
   (with-context previous-balance-ctx
     (testing "An account with no children"
       (testing "and no previous reconciliation"
-        (is (= 0M (recs/previous-balance (find-account "Credit Card")))
+        (is (= 0M (recs/previous-balance (find-account "Credit Card")
+                                         :include-children? true))
             "The previous balance is zero"))
       (testing "and a previous reconciliation"
         (testing "that is completed"
-          (is (= 5000M (recs/previous-balance (find-account "Checking")))
+          (is (= 5000M (recs/previous-balance (find-account "Checking")
+                                              :include-children? true))
             "The previous balance comes from the most recent reconciliation"))
         (testing "that is not completed"
           ; A working (:new) reconciliation dated after the completed one
@@ -377,11 +379,13 @@
                                          :end-of-period (t/local-date 2021 1 31)
                                          :balance 4000M
                                          :status :new})
-          (is (= 5000M (recs/previous-balance (find-account "Checking")))
+          (is (= 5000M (recs/previous-balance (find-account "Checking")
+                                              :include-children? true))
               "The working reconciliation's balance is ignored; the last completed reconciliation still provides the previous balance"))))
     (testing "An account with children"
       (testing "and previous reconciliations at the child level"
-        (is (= 800M (recs/previous-balance (find-account "Savings")))
+        (is (= 800M (recs/previous-balance (find-account "Savings")
+                                           :include-children? true))
             "The previous balance comes from the most recent reconciliation")
         (testing "and a reconciliation at the parent level that \"absorbs\" items from the child accounts."
           (let [savings (find-account "Savings")
@@ -397,12 +401,13 @@
                                :status :completed
                                :balance 1600M
                                :items [car-item reserve-item]})
-            (is (= 1600M (recs/previous-balance savings))
+            (is (= 1600M (recs/previous-balance savings
+                                                :include-children? true))
                 "The parent's own reconciliation balance is used once the child accounts' items are absorbed into it")))))))
 
-(dbtest get-the-previous-reconciliation-balance-excluding-children
+(dbtest get-the-previous-reconciliation-balance
   (with-context previous-balance-ctx
-    (is (= 0M (recs/previous-balance (find-account "Savings") false))
+    (is (= 0M (recs/previous-balance (find-account "Savings")))
         "With include-children? false, the children's reconciliation balances are ignored, even though Savings itself has no reconciliation of its own")
     (testing "and a reconciliation at the parent level"
       (let [savings (find-account "Savings")
@@ -414,7 +419,7 @@
                            :status :completed
                            :balance 1600M
                            :items [car-item reserve-item]})
-        (is (= 1600M (recs/previous-balance savings false))
+        (is (= 1600M (recs/previous-balance savings))
             "Savings' own reconciliation balance is still used when it exists")))))
 
 (def ^:private grandchild-context
@@ -446,7 +451,8 @@
     ; Reserve Sub (a grandchild of Savings, child of Reserve) has its own
     ; completed reconciliation; neither Savings nor Reserve has one. The
     ; grandchild's balance must still be picked up.
-    (is (= 50M (recs/previous-balance (find-account "Savings"))))))
+    (is (= 50M (recs/previous-balance (find-account "Savings")
+                                      :include-children? true)))))
 
 (dbtest previous-balance-excludes-a-grandchild-once-absorbed-by-a-higher-ancestor
   (with-context grandchild-context
@@ -466,7 +472,7 @@
       ; reconciliation two levels up (skipping Reserve, which has no
       ; reconciliation of its own); it must not be counted again -- only
       ; Savings' own new balance (60M) counts going forward.
-      (is (= 60M (recs/previous-balance savings))))))
+      (is (= 60M (recs/previous-balance savings :include-children? true))))))
 
 (dbtest transaction-item-can-only-belong-to-one-reconciliation
   (with-context existing-reconciliation-context


### PR DESCRIPTION
## Summary
- The "previous balance" shown when starting a reconciliation always summed in child account balances, even when the "Include children?" checkbox was unchecked.
- Threads `include-children?` from the checkbox through the frontend API call, the backend API handler, and `clj-money.entities.reconciliations/previous-balance` so unchecking it excludes descendant balances — matching the behavior already in place for the unreconciled-items list.
- Toggling the checkbox now also refreshes the previous balance, not just the item list.

## Test plan
- [x] `lein test clj-money.entities.reconciliations-test clj-money.api.reconciliations-test` — added cases for `include-children? false`
- [x] `lein test` (full backend suite) — 985 tests, 0 failures
- [x] `lein fig:test` (frontend suite) — 108 tests, 0 failures
- [x] `clj-kondo --lint` on changed files — 0 errors/warnings
- [x] `lein cloverage` scoped to touched namespaces — line coverage 99%+

Closes Trello card #338

https://claude.ai/code/session_01DgRpbt48bhkS9r2GUxk97X