### PR TITLE
fix: honor include-children? in reconciliation balance validation

### DIFF
--- a/src/clj_money/api/reconciliations.clj
+++ b/src/clj_money/api/reconciliations.clj
@@ -76,10 +76,12 @@
       (update-in-if [:reconciliation/status] util/ensure-keyword)
       (update-in-if [:reconciliation/balance] bigdec)
       (update-in-if [:reconciliation/items] refine-items)
+      (update-in-if [:reconciliation/include-children?] parse-bool)
       (select-keys [:reconciliation/end-of-period
                     :reconciliation/balance
                     :reconciliation/status
-                    :reconciliation/items])))
+                    :reconciliation/items
+                    :reconciliation/include-children?])))
 
 (defn- create
   [{:keys [authenticated params] :as req}]

--- a/src/clj_money/api/reconciliations.cljs
+++ b/src/clj_money/api/reconciliations.cljs
@@ -78,5 +78,5 @@
             update
             create)]
     (-> recon
-        (schema/prune :reconciliation)
+        (schema/prune :reconciliation :allow [:reconciliation/include-children?])
         (f opts))))

--- a/src/clj_money/entities/reconciliations.clj
+++ b/src/clj_money/entities/reconciliations.clj
@@ -151,6 +151,7 @@
 (s/def :reconciliation/end-of-period t/local-date?)
 (s/def :reconciliation/balance decimal?)
 (s/def :reconciliation/status #{:new :completed})
+(s/def :reconciliation/include-children? boolean?)
 
 (s/def :reconciliation/item
   (s/or :abbreviated (s/keys :req-un [::entities/id])
@@ -163,7 +164,8 @@
                        :reconciliation/end-of-period
                        :reconciliation/status
                        :reconciliation/balance]
-                 :opt [:reconciliation/items])
+                 :opt [:reconciliation/items
+                       :reconciliation/include-children?])
          not-unbalanced?
          no-working-conflict?
          items-belong-to-account?
@@ -188,12 +190,16 @@
     []))
 
 (defn- account+children
-  "Fetch and return the account children along with the given account"
-  [account]
-  (entities/select (util/entity-type
-                     (util/->entity-ref account)
-                     :account)
-                   {:include-children? true}))
+  "Fetch and return the given account as a full entity, along with its
+  children when include-children? is true (the default)"
+  ([account] (account+children account true))
+  ([account include-children?]
+   (entities/select (util/entity-type
+                      (util/->entity-ref account)
+                      :account)
+                    (if include-children?
+                      {:include-children? true}
+                      {}))))
 
 (defn- find-last-completed
   "Returns the last completed reconciliation for an account or any of its
@@ -214,9 +220,7 @@
   rule."
   [account & {:keys [include-children?]}]
   (compute-starting-balance account
-                            (if include-children?
-                              (account+children account)
-                              [])
+                            (account+children account include-children?)
                             nil))
 
 (defn- polarize-item
@@ -234,11 +238,11 @@
                                      :transaction-item/transaction-item]})))
 
 (defmethod entities/before-validation :reconciliation
-  [{:reconciliation/keys [account items] :as recon}]
+  [{:reconciliation/keys [account items include-children?] :as recon}]
   {:pre [(s/valid? (s/nilable :reconciliation/items)
                    (:reconciliation/items recon))]}
   (let [accounts (when account
-                   (index-by :id (account+children account)))
+                   (index-by :id (account+children account include-children?)))
         existing-items (if (:id recon)
                          (fetch-transaction-items recon)
                          [])
@@ -260,6 +264,7 @@
                                               [:transaction-item/account]
                                               (comp accounts :id)))))]
     (-> recon
+        (dissoc :reconciliation/include-children?)
         (update-in [:reconciliation/status] (fnil identity :new))
         (vary-meta
           #(assoc %

--- a/src/clj_money/views/reconciliations.cljs
+++ b/src/clj_money/views/reconciliations.cljs
@@ -57,8 +57,9 @@
 (defn- save-reconciliation*
   [page-state]
   (+busy)
-  (let [{:keys [reconciliation items]} @page-state]
+  (let [{:keys [reconciliation items include-children?]} @page-state]
     (-> reconciliation
+        (assoc :reconciliation/include-children? include-children?)
         (apply-selections items)
         (recs/save :callback -busy
                    :on-success (fn [_created]

--- a/test/clj_money/entities/reconciliations_test.clj
+++ b/test/clj_money/entities/reconciliations_test.clj
@@ -74,7 +74,8 @@
   [attr]
   (helpers/assert-created attr
                           :refs [:reconciliation/account]
-                          :ignore-attributes [:reconciliation/items]
+                          :ignore-attributes [:reconciliation/items
+                                              :reconciliation/include-children?]
                           :compare-result? false))
 
 (defn- attributes []
@@ -202,6 +203,7 @@
                                      :end-of-period (t/local-date 2015 1 31)
                                      :status :completed
                                      :balance 300M
+                                     :include-children? true
                                      :items items})
           simplify #(select-keys % [:transaction-item/action
                                     :transaction-item/account
@@ -235,7 +237,8 @@
         #:reconciliation{:account savings
                          :end-of-period (t/local-date 2015 2 28)
                          :status :completed
-                         :balance 100M}))))
+                         :balance 100M
+                         :include-children? true}))))
 
 (def ^:private absorbable-child-context
   (conj child-reconciliation-context
@@ -264,6 +267,7 @@
                          :end-of-period (t/local-date 2015 2 28)
                          :status :completed
                          :balance 330M
+                         :include-children? true
                          :items [new-car-item]})
       ; That reconciliation swept in one of Car's items, so Car's original
       ; 100M reconciliation is now considered absorbed and must not be added
@@ -274,7 +278,8 @@
         #:reconciliation{:account savings
                          :end-of-period (t/local-date 2015 3 31)
                          :status :completed
-                         :balance 530M}))))
+                         :balance 530M
+                         :include-children? true}))))
 
 (def ^:private previous-balance-ctx
   (conj basic-context
@@ -400,6 +405,7 @@
                                :end-of-period (t/local-date 2021 2 28)
                                :status :completed
                                :balance 1600M
+                               :include-children? true
                                :items [car-item reserve-item]})
             (is (= 1600M (recs/previous-balance savings
                                                 :include-children? true))
@@ -418,9 +424,28 @@
                            :end-of-period (t/local-date 2021 2 28)
                            :status :completed
                            :balance 1600M
+                           :include-children? true
                            :items [car-item reserve-item]})
         (is (= 1600M (recs/previous-balance savings))
             "Savings' own reconciliation balance is still used when it exists")))))
+
+(dbtest completing-a-reconciliation-validates-the-balance-against-the-requested-account-family
+  (with-context previous-balance-ctx
+    (let [savings (find-account "Savings")]
+      (testing "excluding children, the calculated balance ignores their reconciliations"
+        (assert-created
+          #:reconciliation{:account savings
+                           :end-of-period (t/local-date 2021 3 31)
+                           :status :completed
+                           :balance 0M
+                           :include-children? false}))
+      (testing "including children, the calculated balance sums their reconciliations"
+        (assert-created
+          #:reconciliation{:account savings
+                           :end-of-period (t/local-date 2021 4 30)
+                           :status :completed
+                           :balance 800M
+                           :include-children? true})))))
 
 (def ^:private grandchild-context
   (conj parent-account-context
@@ -467,6 +492,7 @@
                          :end-of-period (t/local-date 2015 2 28)
                          :status :completed
                          :balance 60M
+                         :include-children? true
                          :items [new-sub-item]})
       ; Reserve Sub's own 50M reconciliation is now absorbed into Savings'
       ; reconciliation two levels up (skipping Reserve, which has no


### PR DESCRIPTION
## Summary
Follow-up to #262. Once #262 landed, completing a reconciliation with "Include children?" unchecked still failed server-side validation, because `entities.reconciliations/before-validation` always built the account family (and thus the calculated balance) from the account plus *all* its children, regardless of what the client used to compute the submitted balance.

- Thread `:reconciliation/include-children?` from the client through the save request into `before-validation`, which now uses it to decide whether descendant accounts contribute to the calculated balance — matching what `recs/previous-balance` already used for the number shown to the user.
- The flag is transient: it survives frontend schema pruning via an explicit allow-list entry, gets parsed on the API boundary, and is `dissoc`'d before it can reach either persistence backend (required for Datomic, which has no unknown-attribute filtering; harmless-but-necessary for SQL too).
- Along the way, fixed a related bug: `account+children` returned a bare account ref (missing `:account/type` etc.) when children were excluded, which crashed item polarization. It now always fetches the full account entity.
- Updated existing entity tests that implicitly relied on the old "always include children" default, and added a new test covering both include/exclude paths through full entity validation.

## Test plan
- [x] `lein test clj-money.entities.reconciliations-test clj-money.api.reconciliations-test` — 75 tests, 0 failures
- [x] `lein test` (full backend suite) — 987 tests, 0 failures
- [x] `lein fig:test` (frontend suite) — 108 tests, 0 failures
- [x] `clj-kondo --lint` on changed files — 0 errors/warnings
- [x] `lein cloverage` scoped to touched namespaces — 93.79% forms / 99.61% lines

https://claude.ai/code/session_01DgRpbt48bhkS9r2GUxk97X