### PR TITLE
fix: honor include-children? in after-last-reconciliation validation

### DIFF
--- a/src/clj_money/entities/reconciliations.clj
+++ b/src/clj_money/entities/reconciliations.clj
@@ -204,7 +204,9 @@
   against a child account during import)"
   [{:reconciliation/keys [account include-children?] :as recon}]
   (when account
-    (let [ids (map :id (account+children account include-children?))]
+    (let [ids (map :id (if include-children?
+                          (account+children account)
+                          [account]))]
       (entities/find-by (cond-> {:reconciliation/account [:in ids]
                                  :reconciliation/status :completed}
                           (:id recon) (assoc :id [:!= (:id recon)]))

--- a/src/clj_money/entities/reconciliations.clj
+++ b/src/clj_money/entities/reconciliations.clj
@@ -144,7 +144,7 @@
                    (:reconciliation/end-of-period reconciliation)))))
 
 (v/reg-spec after-last-reconciliation?
-            {:message "%s must be after that latest reconciliation"
+            {:message "%s must be after the latest reconciliation"
              :path [:reconciliation/end-of-period]})
 
 (s/def :reconciliation/account ::entities/entity-ref)
@@ -199,11 +199,12 @@
                    {:include-children? true}))
 
 (defn- find-last-completed
-  "Returns the last completed reconciliation for an account or any of its
-  descendants (e.g. one created against a child account during import)"
-  [{:reconciliation/keys [account] :as recon}]
+  "Returns the last completed reconciliation for an account or, when
+  include-children? is true, any of its descendants (e.g. one created
+  against a child account during import)"
+  [{:reconciliation/keys [account include-children?] :as recon}]
   (when account
-    (let [ids (map :id (account+children account))]
+    (let [ids (map :id (account+children account include-children?))]
       (entities/find-by (cond-> {:reconciliation/account [:in ids]
                                  :reconciliation/status :completed}
                           (:id recon) (assoc :id [:!= (:id recon)]))

--- a/test/clj_money/entities/reconciliations_test.clj
+++ b/test/clj_money/entities/reconciliations_test.clj
@@ -138,7 +138,7 @@
     (assert-invalid
       (assoc (attributes)
              :reconciliation/end-of-period (t/local-date 2016 12 31))
-      {:reconciliation/end-of-period ["End of period must be after that latest reconciliation"]})))
+      {:reconciliation/end-of-period ["End of period must be after the latest reconciliation"]})))
 
 (dbtest status-must-be-new-or-completed
   (with-context existing-reconciliation-context
@@ -224,6 +224,20 @@
                          :balance 100M
                          :status :completed
                          :items [[(t/local-date 2015 1 1) 100M]]}))
+
+(dbtest end-of-period-need-not-be-after-a-childs-reconciliation-when-children-are-excluded
+  (with-context child-reconciliation-context
+    (let [savings (find-account "Savings")]
+      ; Car has a completed reconciliation dated 2015-01-31, but Savings does
+      ; not have one of its own. With include-children? false (or
+      ; unspecified), Car's reconciliation must not count as Savings' "last
+      ; reconciliation", so an earlier end-of-period is still valid.
+      (assert-created
+        #:reconciliation{:account savings
+                         :end-of-period (t/local-date 2015 1 15)
+                         :status :completed
+                         :balance 0M
+                         :include-children? false}))))
 
 (dbtest starting-balance-sums-each-childs-own-last-reconciliation-when-the-parent-has-none
   (with-context child-reconciliation-context


### PR DESCRIPTION
## Summary
- `find-last-completed` always searched an account's children for a prior completed reconciliation, ignoring the reconciliation's own `:reconciliation/include-children?` flag, causing valid end-of-period dates to be rejected when a child account happened to have a later reconciliation.
- Fixes a typo in the validation message: "must be after that latest reconciliation" -> "must be after the latest reconciliation".

Trello card: https://trello.com/c/eoKVzFHd/339-after-last-reconciliation-validation-error

## Test plan
- [x] Added `end-of-period-need-not-be-after-a-childs-reconciliation-when-children-are-excluded`, confirmed it fails without the fix and passes with it.
- [x] Updated the typo-dependent assertion in `end-of-period-must-come-after-the-previous-end-of-period`.
- [x] `lein test` — 989 tests, 0 failures, 0 errors.
- [x] `clj-kondo --lint src:test` — 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgRpbt48bhkS9r2GUxk97X