### PR TITLE
ci: split unit tests and docker publish into separate workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,74 +1,30 @@
-name: Clojure CI
+name: Docker Publish
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "Tests" ]
+    types: [ completed ]
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  build:
-
+  gate:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:18
-        env:
-          POSTGRES_PASSWORD: please03
-          POSTGRES_USER: adm_user
-          POSTGRES_DB: adm_user
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-      redis:
-        image: redis:8
-        options: >-
-          --health-cmd "redis-cli -a please04 ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v7.0.1
-      - name: Set up Java 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '21'
-      - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.6.1
-        with:
-          lein: 2.12.0
-          clj-kondo: 2026.01.19
-      - name: Install dependencies
-        run: lein deps
-      - name: Lint with clj-kondo
-        uses: DeLaGuardo/clojure-lint-action@master
-        with:
-          clj-kondo-args: --lint src:test
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run ClojureScript tests
-        run: lein fig:test
-        env:
-          SESSION_SECRET: ci-secret-16byte
-      - name: Set up the database
-        run: lein with-profile +test do create-sql, migrate, migrate-auxiliary, partition 2015-01-01 2017-12-31
-      - name: Run tests
-        run: lein cloverage
-        env:
-          REDIS_PASSWORD: ""
-          SESSION_SECRET: ci-secret-16byte
+      - name: Determine whether to proceed
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event.workflow_run.conclusion }}" = "success" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
 
   tag:
-    needs: build
-    if: github.event_name == 'push'
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true' && github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     permissions: write-all
     concurrency:
@@ -78,6 +34,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v7.0.1
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Determine next version
@@ -97,7 +54,8 @@ jobs:
           git push origin ${{ steps.semver.outputs.next }}
 
   publish-prep:
-    needs: tag
+    needs: [ gate, tag ]
+    if: always() && needs.gate.outputs.proceed == 'true' && (needs.tag.result == 'success' || needs.tag.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.set-time.outputs.timestamp }}
@@ -107,7 +65,8 @@ jobs:
         run: echo "timestamp=$(date +'%Y%m%d-%H%M')" >> $GITHUB_OUTPUT
 
   publish:
-    needs: [tag, publish-prep]
+    needs: [ gate, tag, publish-prep ]
+    if: always() && needs.gate.outputs.proceed == 'true' && (needs.tag.result == 'success' || needs.tag.result == 'skipped') && needs.publish-prep.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -122,6 +81,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Log into docker hub
         uses: docker/login-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,67 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: please03
+          POSTGRES_USER: adm_user
+          POSTGRES_DB: adm_user
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:8
+        options: >-
+          --health-cmd "redis-cli -a please04 ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7.0.1
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@13.6.1
+        with:
+          lein: 2.12.0
+          clj-kondo: 2026.01.19
+      - name: Install dependencies
+        run: lein deps
+      - name: Lint with clj-kondo
+        uses: DeLaGuardo/clojure-lint-action@master
+        with:
+          clj-kondo-args: --lint src:test
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run ClojureScript tests
+        run: lein fig:test
+        env:
+          SESSION_SECRET: ci-secret-16byte
+      - name: Set up the database
+        run: lein with-profile +test do create-sql, migrate, migrate-auxiliary, partition 2015-01-01 2017-12-31
+      - name: Run tests
+        run: lein cloverage
+        env:
+          REDIS_PASSWORD: ""
+          SESSION_SECRET: ci-secret-16byte


### PR DESCRIPTION
## Summary
- Split the single `clojure.yml` CI workflow into `tests.yml` (lint + unit/CLJS tests) and `docker-publish.yml` (versioning + docker image publish).
- Docker publish now triggers automatically when the Tests workflow completes successfully on `main` (via `workflow_run`), and can also be triggered manually via `workflow_dispatch` for PR/branch builds.
- Manual dispatch skips the git version-tagging step (only runs for the automatic post-merge trigger) and publishes with a sha-based image tag rather than `latest`/timestamp tags, which remain reserved for the default branch.

## Test plan
- [ ] Confirm the `Tests` workflow runs on push/PR to `main` as before.
- [ ] Merge to `main` and confirm `Docker Publish` triggers automatically after `Tests` succeeds, tags a new version, and publishes `web`/`util` images with `latest` + timestamp tags.
- [ ] Manually trigger `Docker Publish` via `workflow_dispatch` from this PR's branch and confirm it publishes images (sha-tagged only, no version tag pushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgRpbt48bhkS9r2GUxk97X